### PR TITLE
Hotfix/phpdotenv magento2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
+
+## 3.8.3
+* Fix dependency constraint causing issues with Magento 2.3 installations
     
 ## 3.8.2
 * Enrich customer tagging with address related data

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   "require": {
     "php": ">=5.4.0",
     "phpseclib/phpseclib": "2.0.*",
-    "vlucas/phpdotenv": "2.4.0"
+    "vlucas/phpdotenv": ">=2.4.0"
   },
   "scripts-dev": {
     "post-install-cmd": "if [ -f ./vendor/bin/phpcs ]; then \"vendor/bin/phpcs\" --config-set installed_paths vendor/wimg/php-compatibility; fi",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   "require": {
     "php": ">=5.4.0",
     "phpseclib/phpseclib": "2.0.*",
-    "vlucas/phpdotenv": ">=2.4.0"
+    "vlucas/phpdotenv": ">=2.4.0 <=2.6"
   },
   "scripts-dev": {
     "post-install-cmd": "if [ -f ./vendor/bin/phpcs ]; then \"vendor/bin/phpcs\" --config-set installed_paths vendor/wimg/php-compatibility; fi",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes #157 

## Related Issue
#157 

## Motivation and Context
The fixed and locked phpdotenv dependency (2.4.0) was clashing with Magento 2.3 higher constraint (2.5.1), preventing Nosto extension to be installed via composer in some setups.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This Dev branch was required from Magento and 2.5.1 was installed as expected

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers