### PR TITLE
Fix double encoding for oauth redirect URLs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+## 3.9.1
+* Fix double URL encoding issue in Oauth URLs
+
 ## 3.9.0
 * Handle HTTP/2 response codes correctly
 * Refactor test cases

--- a/src/Helper/OAuthHelper.php
+++ b/src/Helper/OAuthHelper.php
@@ -62,7 +62,7 @@ class OAuthHelper extends AbstractHelper
             $oauthBaseUrl . self::PATH_AUTH,
             array(
                 '{cid}' => $params->getClientId(),
-                '{uri}' => urlencode($params->getRedirectUrl()),
+                '{uri}' => $params->getRedirectUrl(),
                 '{sco}' => implode(' ', $params->getScopes()),
                 '{iso}' => strtolower($params->getLanguageIsoCode()),
             )

--- a/src/Operation/OAuth/AuthorizationCode.php
+++ b/src/Operation/OAuth/AuthorizationCode.php
@@ -107,7 +107,7 @@ class AuthorizationCode
             array(
                 '{cid}' => $this->clientId,
                 '{sec}' => $this->clientSecret,
-                '{uri}' => urlencode($this->redirectUrl),
+                '{uri}' => $this->redirectUrl,
                 '{cod}' => $code
             )
         );

--- a/tests/unit/Helper/OAuthHelperTest.php
+++ b/tests/unit/Helper/OAuthHelperTest.php
@@ -54,11 +54,11 @@ class OAuthHelperTest extends Test
         $url = OAuthHelper::getAuthorizationUrl($meta);
         $this->specify('oauth authorize url can be created', function () use ($url) {
             $url = parse_url($url);
-            parse_str($url['query'], $params);
+            parse_str($url['query'], $params); // Please note that this function url decodes the values
 
             $this->assertEquals($url['path'], '/oauth');
             $this->assertEquals($params['client_id'], 'client-id');
-            $this->assertEquals($params['redirect_uri'], urlencode('http://my.shop.com/nosto/oauth'));
+            $this->assertEquals($params['redirect_uri'], 'http://my.shop.com/nosto/oauth');
             $this->assertEquals($params['response_type'], 'code');
             $this->assertEquals($params['scope'], 'sso products');
             $this->assertEquals($params['lang'], 'en');


### PR DESCRIPTION
Fixes double oauth redirect url issue. Closes #172 

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers