### PR TITLE
Add check for floating zero

### DIFF
--- a/src/Helper/HtmlMarkupSerializationHelper.php
+++ b/src/Helper/HtmlMarkupSerializationHelper.php
@@ -91,7 +91,7 @@ class HtmlMarkupSerializationHelper extends AbstractHelper
      */
     private static function toHtml($object, $key, $spaces = 0, $indent = 2, $style = null)
     {
-        if (!$object && $object !== 0 && $object !== '0' && $object !== false) {
+        if (!$object && $object !== 0 && $object !== '0' && $object !== false && $object !== 0.00) {
             return "";
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Check the $object variable for floating zero value, else it does return an empty string while serializing the HTML tag. 

## Related Issue
closes #175

## Motivation and Context
It was observed that in Magento2, products that had price zero were not serialized as they should, skipping the price tag. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers