### PR TITLE
Add possibility to define Nosto account & active domain for API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+## 3.10.1
+* Add Nosto account & active domain to the API calls 
+
 ## 3.10.0
 * Implement automatic HTML entity encoding for objects 
 

--- a/src/Helper/UrlHelper.php
+++ b/src/Helper/UrlHelper.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright (c) 2019, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2019 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+/**
+ * Copyright (c) 2019, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2019 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+namespace Nosto\Helper;
+
+use Nosto\NostoException;
+
+
+class UrlHelper extends AbstractHelper
+{
+
+    /**
+     * Returns the host
+     *
+     * @param string $url
+     * @return string
+     * @throws NostoException
+     */
+    public static function parseUrl($url)
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL)) {
+            return parse_url($url, PHP_URL_HOST);
+        }
+
+        throw new NostoException('The string is not a valid URL');
+    }
+}

--- a/src/Helper/UrlHelper.php
+++ b/src/Helper/UrlHelper.php
@@ -34,40 +34,6 @@
  *
  */
 
-/**
- * Copyright (c) 2019, Nosto Solutions Ltd
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * @author Nosto Solutions Ltd <contact@nosto.com>
- * @copyright 2019 Nosto Solutions Ltd
- * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
- *
- */
 namespace Nosto\Helper;
 
 use Nosto\NostoException;

--- a/src/Operation/AbstractAuthenticatedOperation.php
+++ b/src/Operation/AbstractAuthenticatedOperation.php
@@ -50,12 +50,19 @@ abstract class AbstractAuthenticatedOperation extends AbstractOperation
     protected $account;
 
     /**
+     * @var string active domain
+     */
+    protected $activeDomain;
+
+    /**
      * Constructor
      *
      * @param AccountInterface $account the account object.
+     * @param string $activeDomain
      */
-    public function __construct(AccountInterface $account)
+    public function __construct(AccountInterface $account, $activeDomain = '')
     {
         $this->account = $account;
+        $this->activeDomain = $activeDomain;
     }
 }

--- a/src/Operation/AbstractOperation.php
+++ b/src/Operation/AbstractOperation.php
@@ -39,6 +39,7 @@ namespace Nosto\Operation;
 use Nosto\NostoException;
 use Nosto\Request\Api\ApiRequest;
 use Nosto\Request\Api\Token;
+use Nosto\Request\Http\Exception\AbstractHttpException;
 use Nosto\Request\Http\HttpRequest;
 use Nosto\Request\Http\HttpResponse;
 use Nosto\Exception\Builder as ExceptionBuilder;
@@ -69,7 +70,7 @@ abstract class AbstractOperation
      * @param $request HttpRequest the HTTP request
      * @param $response HttpResponse the HTTP response to check
      * @return bool returns true when everything was okay
-     * @throws \Nosto\Request\Http\Exception\AbstractHttpException
+     * @throws AbstractHttpException
      */
     protected static function checkResponse(HttpRequest $request, HttpResponse $response)
     {
@@ -84,16 +85,27 @@ abstract class AbstractOperation
      * of 'application/json' and the specified authentication token
      *
      * @param Token|null $token the token to use for the endpoint
+     * @param string|null $nostoAccount
+     * @param string|null $domain
      * @return ApiRequest the newly created request object.
      * @throws NostoException if the account does not have the correct token set.
      */
-    protected function initApiRequest(Token $token = null)
-    {
+    protected function initApiRequest(
+        Token $token = null,
+        $nostoAccount = null,
+        $domain = null
+    ) {
         if (is_null($token)) {
             throw new NostoException('No API token found for account.');
         }
-
         $request = new ApiRequest();
+        if (is_string($domain)) {
+            $request->setActiveDomainHeader($domain);
+        }
+        if (is_string($nostoAccount)) {
+            $request->setNostoAccountHeader($nostoAccount);
+        }
+
         $request->setResponseTimeout($this->getResponseTimeout());
         $request->setConnectTimeout($this->getConnectTimeout());
         $request->setContentType(self::CONTENT_TYPE_APPLICATION_JSON);
@@ -106,16 +118,26 @@ abstract class AbstractOperation
      * of 'application/x-www-form-urlencoded' and the specified authentication token
      *
      * @param Token|null $token the token to use for the endpoint
+     * @param string|null $nostoAccount
+     * @param string|null $domain
      * @return HttpRequest the newly created request object.
      * @throws NostoException if the account does not have the correct token set.
      */
-    protected function initHttpRequest(Token $token = null)
-    {
+    protected function initHttpRequest(
+        Token $token = null,
+        $nostoAccount = null,
+        $domain = null
+    ) {
         if (is_null($token)) {
             throw new NostoException('No API token found for account.');
         }
-
         $request = new HttpRequest();
+        if (is_string($domain)) {
+            $request->setActiveDomainHeader($domain);
+        }
+        if (is_string($nostoAccount)) {
+            $request->setNostoAccountHeader($nostoAccount);
+        }
         $request->setResponseTimeout($this->getResponseTimeout());
         $request->setConnectTimeout($this->getConnectTimeout());
         $request->setContentType(self::CONTENT_TYPE_URL_FORM_ENCODED);

--- a/src/Operation/DeleteProduct.php
+++ b/src/Operation/DeleteProduct.php
@@ -40,6 +40,7 @@ use Nosto\NostoException;
 use Nosto\Request\Api\ApiRequest;
 use Nosto\Request\Api\Token;
 use Nosto\Request\Http\Exception\AbstractHttpException;
+use Nosto\Types\Signup\AccountInterface;
 
 /**
  * Operation class for upserting and deleting products through the Nosto API.
@@ -53,6 +54,16 @@ class DeleteProduct extends AbstractAuthenticatedOperation
      * @var array
      */
     private $productIds;
+
+    /**
+     * DeleteProduct constructor.
+     * @param AccountInterface $account
+     * @param string $activeDomain
+     */
+    public function __construct(AccountInterface $account, $activeDomain = '')
+    {
+        parent::__construct($account, $activeDomain);
+    }
 
     /**
      * Adds a product tho the collection on which the operation is the performed.
@@ -73,9 +84,13 @@ class DeleteProduct extends AbstractAuthenticatedOperation
      */
     public function delete()
     {
-        $request = $this->initApiRequest($this->account->getApiToken(Token::API_PRODUCTS));
+        $request = $this->initApiRequest(
+            $this->account->getApiToken(Token::API_PRODUCTS),
+            $this->account->getName(),
+            $this->activeDomain
+        );
         $request->setPath(ApiRequest::PATH_PRODUCTS_DISCONTINUE);
         $response = $request->post($this->productIds);
-        return $this->checkResponse($request, $response);
+        return self::checkResponse($request, $response);
     }
 }

--- a/src/Operation/InitiateSso.php
+++ b/src/Operation/InitiateSso.php
@@ -61,7 +61,10 @@ class InitiateSso extends AbstractAuthenticatedOperation
      */
     public function get(UserInterface $user, $platform)
     {
-        $request = $this->initHttpRequest($this->account->getApiToken(Token::API_SSO));
+        $request = $this->initHttpRequest(
+            $this->account->getApiToken(Token::API_SSO),
+            $this->account->getName()
+        );
         $request->setPath(ApiRequest::PATH_SSO_AUTH);
         $request->setContentType(self::CONTENT_TYPE_APPLICATION_JSON);
         $request->setReplaceParams(array('{platform}' => $platform));

--- a/src/Operation/MarketingPermission.php
+++ b/src/Operation/MarketingPermission.php
@@ -38,12 +38,23 @@ namespace Nosto\Operation;
 
 use Nosto\Request\Api\ApiRequest;
 use Nosto\Request\Api\Token;
+use Nosto\Types\Signup\AccountInterface;
 
 /**
  * Operation class for updated customer's marketing permission
  */
 class MarketingPermission extends AbstractAuthenticatedOperation
 {
+    /**
+     * MarketingPermission constructor.
+     * @param AccountInterface $account
+     * @param string $activeDomain
+     */
+    public function __construct(AccountInterface $account, $activeDomain = '')
+    {
+        parent::__construct($account, $activeDomain);
+    }
+
     /**
      * Update customer marketing permission
      * @param string $email
@@ -52,13 +63,17 @@ class MarketingPermission extends AbstractAuthenticatedOperation
      */
     public function update($email, $hasPermission)
     {
-        $request = $this->initApiRequest($this->account->getApiToken(Token::API_EMAIL));
+        $request = $this->initApiRequest(
+            $this->account->getApiToken(Token::API_EMAIL),
+            $this->account->getName(),
+            $this->activeDomain
+        );
 
         $request->setPath(ApiRequest::PATH_MARKETING_PERMISSION);
         $replaceParams = array('{email}' => $email, '{state}' => $hasPermission ? 'true' : 'false');
         $request->setReplaceParams($replaceParams);
         $response = $request->postRaw('');
 
-        return $this->checkResponse($request, $response);
+        return self::checkResponse($request, $response);
     }
 }

--- a/src/Operation/OrderConfirm.php
+++ b/src/Operation/OrderConfirm.php
@@ -59,7 +59,12 @@ class OrderConfirm extends AbstractAuthenticatedOperation
      * @return true on success.
      * @throws AbstractHttpException
      */
-    public function send(OrderInterface $order, $customerId = null)
+    public function send(
+        OrderInterface $order,
+        $customerId = null,
+        $nostoAccount = null,
+        $activeDomain = null
+    )
     {
         $request = new ApiRequest();
         if (!empty($customerId)) {
@@ -69,8 +74,14 @@ class OrderConfirm extends AbstractAuthenticatedOperation
             $request->setPath(ApiRequest::PATH_UNMATCHED_ORDER_TAGGING);
             $replaceParams = array('{m}' => $this->account->getName());
         }
+        if (is_string($activeDomain)) {
+            $request->setActiveDomainHeader($activeDomain);
+        }
+        if (is_string($nostoAccount)) {
+            $request->setNostoAccountHeader($nostoAccount);
+        }
         $request->setReplaceParams($replaceParams);
         $response = $request->post($order);
-        return $this->checkResponse($request, $response);
+        return self::checkResponse($request, $response);
     }
 }

--- a/src/Operation/OrderConfirm.php
+++ b/src/Operation/OrderConfirm.php
@@ -39,6 +39,7 @@ namespace Nosto\Operation;
 use Nosto\Request\Api\ApiRequest;
 use Nosto\Request\Http\Exception\AbstractHttpException;
 use Nosto\Types\Order\OrderInterface;
+use Nosto\Types\Signup\AccountInterface;
 
 /**
  * Handles sending the OrderConfirm confirmations to Nosto via the API.
@@ -52,6 +53,16 @@ use Nosto\Types\Order\OrderInterface;
 class OrderConfirm extends AbstractAuthenticatedOperation
 {
     /**
+     * OrderConfirm constructor.
+     * @param AccountInterface $account
+     * @param string $activeDomain
+     */
+    public function __construct(AccountInterface $account, $activeDomain = '')
+    {
+        parent::__construct($account, $activeDomain);
+    }
+
+    /**
      * Sends the OrderConfirm confirmation to Nosto.
      *
      * @param OrderInterface $order the placed OrderConfirm model.
@@ -59,12 +70,7 @@ class OrderConfirm extends AbstractAuthenticatedOperation
      * @return true on success.
      * @throws AbstractHttpException
      */
-    public function send(
-        OrderInterface $order,
-        $customerId = null,
-        $nostoAccount = null,
-        $activeDomain = null
-    )
+    public function send(OrderInterface $order, $customerId = null)
     {
         $request = new ApiRequest();
         if (!empty($customerId)) {
@@ -74,11 +80,11 @@ class OrderConfirm extends AbstractAuthenticatedOperation
             $request->setPath(ApiRequest::PATH_UNMATCHED_ORDER_TAGGING);
             $replaceParams = array('{m}' => $this->account->getName());
         }
-        if (is_string($activeDomain)) {
-            $request->setActiveDomainHeader($activeDomain);
+        if (is_string($this->activeDomain)) {
+            $request->setActiveDomainHeader($this->activeDomain);
         }
-        if (is_string($nostoAccount)) {
-            $request->setNostoAccountHeader($nostoAccount);
+        if (is_string($this->account->getName())) {
+            $request->setNostoAccountHeader($this->account->getName());
         }
         $request->setReplaceParams($replaceParams);
         $response = $request->post($order);

--- a/src/Operation/Recommendation/AbstractOperation.php
+++ b/src/Operation/Recommendation/AbstractOperation.php
@@ -42,6 +42,7 @@ use Nosto\Operation\AbstractAuthenticatedOperation;
 use Nosto\Request\Graphql\GraphqlRequest;
 use Nosto\Request\Http\Exception\AbstractHttpException;
 use Nosto\Request\Api\Token;
+use Nosto\Request\Http\Exception\HttpResponseException;
 use Nosto\Result\Graphql\ResultSet;
 use Nosto\Result\Graphql\ResultSetBuilder;
 use Nosto\Exception\Builder as ExceptionBuilder;
@@ -70,6 +71,7 @@ abstract class AbstractOperation extends AbstractAuthenticatedOperation
      *
      * @return GraphqlRequest the newly created request object.
      * @throws NostoException if the account does not have the correct token set.
+     * @throws NostoException
      */
     protected function initGraphqlRequest()
     {
@@ -102,10 +104,10 @@ abstract class AbstractOperation extends AbstractAuthenticatedOperation
     /**
      * Returns the result
      *
+     * @return ResultSet
      * @throws AbstractHttpException
      * @throws NostoException
-     * @return ResultSet
-     *
+     * @throws HttpResponseException
      */
     public function execute()
     {

--- a/src/Operation/SyncRates.php
+++ b/src/Operation/SyncRates.php
@@ -41,12 +41,23 @@ use Nosto\Object\ExchangeRateCollection;
 use Nosto\Request\Api\ApiRequest;
 use Nosto\Request\Api\Token;
 use Nosto\Request\Http\Exception\AbstractHttpException;
+use Nosto\Types\Signup\AccountInterface;
 
 /**
  * Handles updating exchange rates through the Nosto API
  */
 class SyncRates extends AbstractAuthenticatedOperation
 {
+    /**
+     * SyncRates constructor.
+     * @param AccountInterface $account
+     * @param string $activeDomain
+     */
+    public function __construct(AccountInterface $account, $activeDomain = '')
+    {
+        parent::__construct($account, $activeDomain);
+    }
+
     /**
      * Updates exchange rates to Nosto
      *
@@ -57,9 +68,13 @@ class SyncRates extends AbstractAuthenticatedOperation
      */
     public function update(ExchangeRateCollection $collection)
     {
-        $request = $this->initApiRequest($this->account->getApiToken(Token::API_EXCHANGE_RATES));
+        $request = $this->initApiRequest(
+            $this->account->getApiToken(Token::API_EXCHANGE_RATES),
+            $this->account->getName(),
+            $this->activeDomain
+        );
         $request->setPath(ApiRequest::PATH_CURRENCY_EXCHANGE_RATE);
         $response = $request->post($collection);
-        return $this->checkResponse($request, $response);
+        return self::checkResponse($request, $response);
     }
 }

--- a/src/Operation/UpdateSettings.php
+++ b/src/Operation/UpdateSettings.php
@@ -41,12 +41,23 @@ use Nosto\Request\Api\ApiRequest;
 use Nosto\Request\Api\Token;
 use Nosto\Request\Http\Exception\AbstractHttpException;
 use Nosto\Types\SettingsInterface;
+use Nosto\Types\Signup\AccountInterface;
 
 /**
  * Operation class for updating common account settings through the Nosto API.
  */
 class UpdateSettings extends AbstractAuthenticatedOperation
 {
+    /**
+     * UpdateSettings constructor.
+     * @param AccountInterface $account
+     * @param string $activeDomain
+     */
+    public function __construct(AccountInterface $account, $activeDomain = '')
+    {
+        parent::__construct($account, $activeDomain);
+    }
+
     /**
      * Sends a POST request to create a new account for a store in Nosto
      *
@@ -57,9 +68,13 @@ class UpdateSettings extends AbstractAuthenticatedOperation
      */
     public function update(SettingsInterface $settings)
     {
-        $request = $this->initApiRequest($this->account->getApiToken(Token::API_SETTINGS));
+        $request = $this->initApiRequest(
+            $this->account->getApiToken(Token::API_SETTINGS),
+            $this->account->getName(),
+            $this->activeDomain
+        );
         $request->setPath(ApiRequest::PATH_SETTINGS);
         $response = $request->put($settings);
-        return $this->checkResponse($request, $response);
+        return self::checkResponse($request, $response);
     }
 }

--- a/src/Operation/UpsertProduct.php
+++ b/src/Operation/UpsertProduct.php
@@ -61,10 +61,11 @@ class UpsertProduct extends AbstractAuthenticatedOperation
      * Constructor.
      *
      * @param AccountInterface $account the account object.
+     * @param string $activeDomain
      */
-    public function __construct(AccountInterface $account)
+    public function __construct(AccountInterface $account, $activeDomain = '')
     {
-        parent::__construct($account);
+        parent::__construct($account, $activeDomain);
         $this->collection = new ProductCollection();
     }
 
@@ -82,12 +83,17 @@ class UpsertProduct extends AbstractAuthenticatedOperation
      * Sends a POST request to create or update all the products currently in the collection.
      *
      * @return bool if the request was successful.
-     * @throws NostoException on failure.
      * @throws AbstractHttpException
+     * @throws NostoException on failure.
+     * @throws \Exception
      */
     public function upsert()
     {
-        $request = $this->initApiRequest($this->account->getApiToken(Token::API_PRODUCTS));
+        $request = $this->initApiRequest(
+            $this->account->getApiToken(Token::API_PRODUCTS),
+            $this->account->getName(),
+            $this->activeDomain
+        );
         $request->setPath(ApiRequest::PATH_PRODUCTS_UPSERT);
         $response = $request->post($this->collection);
         return $this->checkResponse($request, $response);

--- a/src/Request/Http/HttpRequest.php
+++ b/src/Request/Http/HttpRequest.php
@@ -67,6 +67,8 @@ class HttpRequest
     const METHOD_DELETE = 'DELETE';
     const HEADER_AUTHORIZATION = 'Authorization';
     const HEADER_CONTENT_TYPE = 'Content-type';
+    const HEADER_NOSTO_ACCOUNT= 'X-Nosto-account';
+    const HEADER_ACTIVE_DOMAIN = 'X-Nosto-active-domain';
 
     /**
      * @var string user-agent to use for all requests
@@ -119,7 +121,6 @@ class HttpRequest
      * Curl is preferred if available.
      *
      * @param Adapter|null $adapter the http request adapter to use
-     * @throws NostoException
      */
     public function __construct(Adapter $adapter = null)
     {
@@ -263,6 +264,22 @@ class HttpRequest
     }
 
     /**
+     * Adds Nosto account to the headers
+     * @param $nostoAccount
+     */
+    public function setNostoAccountHeader($nostoAccount) {
+        $this->addHeader(self::HEADER_NOSTO_ACCOUNT, $nostoAccount);
+    }
+
+    /**
+     * Adds active domain to the headers
+     * @param $activeDomain
+     */
+    public function setActiveDomainHeader($activeDomain) {
+        $this->addHeader(self::HEADER_ACTIVE_DOMAIN, $activeDomain);
+    }
+
+    /**
      * Adds a new header to the request.
      *
      * @param string $key the header key, e.g. 'Content-type'.
@@ -318,6 +335,7 @@ class HttpRequest
      *
      * @param string $username the user name.
      * @param string $password the password.
+     * @throws NostoException
      */
     public function setAuthBasic($username, $password)
     {
@@ -329,7 +347,7 @@ class HttpRequest
      *
      * @param string $type the auth type (use AUTH_ constants).
      * @param mixed $value the auth header value, format depending on the auth type.
-     * @throws Exception if an incorrect auth type is given.
+     * @throws NostoException if an incorrect auth type is given.
      */
     public function setAuth($type, $value)
     {
@@ -356,6 +374,7 @@ class HttpRequest
      * Convenience method for setting the bearer auth type.
      *
      * @param string $token the access token.
+     * @throws Exception
      */
     public function setAuthBearer($token)
     {

--- a/tests/unit/HttpRequestTest.php
+++ b/tests/unit/HttpRequestTest.php
@@ -83,6 +83,34 @@ class HttpRequestTest extends Test
     }
 
     /**
+     * Tests that domain header is correct
+     */
+    public function testHttpRequestDomainHeader()
+    {
+        $request = new HttpRequest();
+        $request->setActiveDomainHeader('test.nos.to');
+        $headers = $request->getHeaders();
+        $this->assertContains(
+            'X-Nosto-active-domain: test.nos.to'
+            , $headers
+        );
+    }
+
+    /**
+     * Test that account header is correct
+     */
+    public function testHttpRequestAccountHeader()
+    {
+        $request = new HttpRequest();
+        $request->setNostoAccountHeader('test-account');
+        $headers = $request->getHeaders();
+        $this->assertContains(
+            'X-Nosto-account: test-account'
+            , $headers
+        );
+    }
+
+    /**
      * Tests setting the bearer auth type.
      */
     public function testHttpRequestAuthBearer()

--- a/tests/unit/Operation/ProductTest.php
+++ b/tests/unit/Operation/ProductTest.php
@@ -113,6 +113,26 @@ class ProductTest extends Test
     /**
      * Tests that product upsert API requests can be made.
      */
+    public function testUpsertWithDomain()
+    {
+        $account = new Account('platform-00000000');
+        $product = new MockProduct();
+
+        $token = new Token('products', 'token');
+        $account->addApiToken($token);
+
+        $op = new UpsertProduct($account, 'test.nos.to');
+        $op->addProduct($product);
+        $result = $op->upsert();
+
+        $this->specify('successful product upsert', function () use ($result) {
+            $this->assertTrue($result);
+        });
+    }
+
+    /**
+     * Tests that product upsert API requests can be made.
+     */
     public function testSendingProductVariations()
     {
         $account = new Account('platform-00000000');


### PR DESCRIPTION
closes #182 #131   

## Description
* Add possibility to define active domain and Nosto account for API calls and HTTP requests in general

## Related Issue
#182 
#131 

## Motivation and Context
We check on Nosto's end that the active domain is in the allowed domains. This will also help us debug API related issues. 

## How Has This Been Tested?
* ToDo - add some tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers