### PR TITLE
Add method to check if array contains only scalable values

### DIFF
--- a/src/Helper/ArrayHelper.php
+++ b/src/Helper/ArrayHelper.php
@@ -34,64 +34,50 @@
  *
  */
 
-namespace Nosto\Result\Graphql;
+namespace Nosto\Helper;
 
-use Nosto\Helper\ArrayHelper;
-use Nosto\NostoException;
-use Nosto\Operation\Recommendation\AbstractOperation;
-use Nosto\Request\Http\HttpResponse;
 
-/**
- * Builder / parser class for GraphQL result and response
- */
-class ResultSetBuilder
+class ArrayHelper extends AbstractHelper
 {
     /**
-     * Builds a result set from HttpResponse
+     * Check if the array contains only strings or numeric values
      *
-     * @param HttpResponse $httpResponse
-     * @return ResultSet
-     * @throws NostoException
+     * @param $array
+     * @return bool
      */
-    public static function fromHttpResponse(HttpResponse $httpResponse)
+    public static function onlyScalarValues($array)
     {
-        $result = json_decode($httpResponse->getResult());
-        $primaryData = self::parsePrimaryData($result);
-        $resultSet = new ResultSet();
-        foreach ($primaryData as $primaryDataItem) {
-            if ($primaryDataItem instanceof \stdClass) {
-                $primaryDataItem = ArrayHelper::stdClassToArray($primaryDataItem);
+        foreach ($array as $elem) {
+            if (!is_scalar($elem)) {
+                return false;
             }
-            $item = new ResultItem($primaryDataItem);
-            $resultSet->append($item);
         }
-        return $resultSet;
+        return true;
     }
 
     /**
-     * Finds the primary data field from stdClass
+     * Checks whether an array is associative or sequentially indexed as associative arrays are
+     * handled as objects
      *
-     * @param \stdClass $class
-     * @return array
-     * @throws NostoException
+     * @param array $arr the array to check
+     * @return bool true if the array is associative
      */
-    public static function parsePrimaryData(\stdClass $class)
+    public static function isAssoc(array $arr)
     {
-        $members = get_object_vars($class);
-        foreach ($members as $varName => $member) {
-            if ($varName == AbstractOperation::GRAPHQL_DATA_KEY) {
-                return $member;
-            }
-            if ($member instanceof \stdClass) {
-                return self::parsePrimaryData($member);
-            }
+        if (array() === $arr) {
+            return false;
         }
+        return array_keys($arr) !== range(0, count($arr) - 1);
+    }
 
-        throw new NostoException(
-            sprintf(
-                'Could not find primary data field (%s) from response',
-                AbstractOperation::GRAPHQL_DATA_KEY
-            )
-        );
+    /**
+     * Converts stdClass to a map
+     *
+     * @param \stdClass $object
+     * @return mixed
+     */
+    public static function stdClassToArray(\stdClass $object)
+    {
+        return json_decode(json_encode($object), true);
     }
 }

--- a/src/Helper/HtmlMarkupSerializationHelper.php
+++ b/src/Helper/HtmlMarkupSerializationHelper.php
@@ -158,7 +158,7 @@ class HtmlMarkupSerializationHelper extends AbstractHelper
     private static function arrayToHtml($object, $key, $spaces, $indent, $traversable, $snakeCaseKey)
     {
         $markup = '';
-        $isAssociative = is_array($traversable) && SerializationHelper::isAssoc($traversable);
+        $isAssociative = is_array($traversable) && ArrayHelper::isAssoc($traversable);
         foreach ($traversable as $index => $childValue) {
             if ($object instanceof MarkupableCollectionInterface && $object->getChildMarkupKey()) {
                 $childMarkupKey = $object->getChildMarkupKey();

--- a/src/Helper/SerializationHelper.php
+++ b/src/Helper/SerializationHelper.php
@@ -103,7 +103,7 @@ class SerializationHelper extends AbstractHelper
             } else {
                 if (is_array($value)) {
                     $json[$key] = array();
-                    if (self::isAssoc($value)) {
+                    if (ArrayHelper::isAssoc($value)) {
                         foreach ($value as $k => $anObject) {
                             if (is_object($anObject)) {
                                 $json[$key][$k] = self::toArray($anObject);
@@ -184,31 +184,5 @@ class SerializationHelper extends AbstractHelper
             $match = $match == strtoupper($match) ? strtolower($match) : lcfirst($match);
         }
         return implode('_', $ret);
-    }
-
-    /**
-     * Checks whether an array is associative or sequentially indexed as associative arrays are
-     * handled as objects
-     *
-     * @param array $arr the array to check
-     * @return bool true if the array is associative
-     */
-    public static function isAssoc(array $arr)
-    {
-        if (array() === $arr) {
-            return false;
-        }
-        return array_keys($arr) !== range(0, count($arr) - 1);
-    }
-
-    /**
-     * Converts stdClass to a map
-     *
-     * @param \stdClass $object
-     * @return mixed
-     */
-    public static function stdClassToArray(\stdClass $object)
-    {
-        return json_decode(json_encode($object), true);
     }
 }

--- a/tests/unit/Helper/ArrayHelperTest.php
+++ b/tests/unit/Helper/ArrayHelperTest.php
@@ -34,64 +34,22 @@
  *
  */
 
-namespace Nosto\Result\Graphql;
+namespace Nosto\Test\Unit\Helper;
 
+use Codeception\TestCase\Test;
 use Nosto\Helper\ArrayHelper;
-use Nosto\NostoException;
-use Nosto\Operation\Recommendation\AbstractOperation;
-use Nosto\Request\Http\HttpResponse;
 
-/**
- * Builder / parser class for GraphQL result and response
- */
-class ResultSetBuilder
+class ArrayHelperTest extends Test
 {
-    /**
-     * Builds a result set from HttpResponse
-     *
-     * @param HttpResponse $httpResponse
-     * @return ResultSet
-     * @throws NostoException
+    /*
+     *  Test that onlyScalarValues() method return the correct bool value
      */
-    public static function fromHttpResponse(HttpResponse $httpResponse)
+    public function testOnlyScalarValues()
     {
-        $result = json_decode($httpResponse->getResult());
-        $primaryData = self::parsePrimaryData($result);
-        $resultSet = new ResultSet();
-        foreach ($primaryData as $primaryDataItem) {
-            if ($primaryDataItem instanceof \stdClass) {
-                $primaryDataItem = ArrayHelper::stdClassToArray($primaryDataItem);
-            }
-            $item = new ResultItem($primaryDataItem);
-            $resultSet->append($item);
-        }
-        return $resultSet;
-    }
+        $scalarArray = [ 1, 2, 3, 4, 'five' ];
+        $nonScalarArray = [ [2,3,4], ['test', 'string'], 2 ];
 
-    /**
-     * Finds the primary data field from stdClass
-     *
-     * @param \stdClass $class
-     * @return array
-     * @throws NostoException
-     */
-    public static function parsePrimaryData(\stdClass $class)
-    {
-        $members = get_object_vars($class);
-        foreach ($members as $varName => $member) {
-            if ($varName == AbstractOperation::GRAPHQL_DATA_KEY) {
-                return $member;
-            }
-            if ($member instanceof \stdClass) {
-                return self::parsePrimaryData($member);
-            }
-        }
-
-        throw new NostoException(
-            sprintf(
-                'Could not find primary data field (%s) from response',
-                AbstractOperation::GRAPHQL_DATA_KEY
-            )
-        );
+        $this->assertTrue(ArrayHelper::onlyScalarValues($scalarArray));
+        $this->assertFalse(ArrayHelper::onlyScalarValues($nonScalarArray));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add `ArrayHelper` class.
* Add method to check if an array contains only scalar values
* Migrate `SerializationHelper::isAssoc` and `SerializationHelper::stdClassToArray` to ArrayHelper

## Related Issue
closes #190

## How Has This Been Tested?
Created unit test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers