### PR TITLE
Add APPS token to the default tokens when creating Nosto Account

### DIFF
--- a/src/Helper/HtmlMarkupSerializationHelper.php
+++ b/src/Helper/HtmlMarkupSerializationHelper.php
@@ -233,7 +233,7 @@ class HtmlMarkupSerializationHelper extends AbstractHelper
      * @param $value
      * @return bool
      */
-    public static function canEncoded($value)
+    public static function canBeEncoded($value)
     {
         if (is_string($value) || $value instanceof StringCollection) {
             return true;
@@ -241,7 +241,7 @@ class HtmlMarkupSerializationHelper extends AbstractHelper
         // We need to check that the array contains only scalar values or other arrays
         if (is_array($value)) {
             foreach ($value as $item) {
-                if (!self::canEncoded($item)) {
+                if (!self::canBeEncoded($item)) {
                     return false;
                 }
             }

--- a/src/Mixins/HtmlEncoderTrait.php
+++ b/src/Mixins/HtmlEncoderTrait.php
@@ -116,7 +116,7 @@ trait HtmlEncoderTrait
             $getter = 'get' . str_replace('_', '', $field);
             $setter = 'set' . str_replace('_', '', $field);
             $origVal = $this->{$getter}();
-            if (HtmlMarkupSerializationHelper::canEncoded($origVal)) {
+            if (HtmlMarkupSerializationHelper::canBeEncoded($origVal)) {
                 $encodedVal = HtmlMarkupSerializationHelper::encodeHtmlEntities($origVal);
                 $this->{$setter}($encodedVal);
             }

--- a/src/Object/Signup/Signup.php
+++ b/src/Object/Signup/Signup.php
@@ -106,11 +106,17 @@ class Signup extends Settings implements SignupInterface
         $this->setPlatform($platform);
         $this->setSignupApiToken(new Token(Token::API_CREATE, $signupApiToken));
         $this->setPartnerCode($partnerCode);
-        $this->addApiToken(Token::API_PRODUCTS);
-        $this->addApiToken(Token::API_SSO);
-        $this->addApiToken(Token::API_EXCHANGE_RATES);
-        $this->addApiToken(Token::API_SETTINGS);
-        $this->addApiToken(Token::API_EMAIL);
+        $tokens  = [
+            Token::API_PRODUCTS,
+            Token::API_SSO,
+            Token::API_EXCHANGE_RATES,
+            Token::API_SETTINGS,
+            Token::API_EMAIL,
+            Token::API_GRAPHQL
+        ];
+        foreach ($tokens as $token) {
+            $this->addApiToken($token);
+        }
     }
 
     /**

--- a/src/Object/Signup/Signup.php
+++ b/src/Object/Signup/Signup.php
@@ -106,15 +106,7 @@ class Signup extends Settings implements SignupInterface
         $this->setPlatform($platform);
         $this->setSignupApiToken(new Token(Token::API_CREATE, $signupApiToken));
         $this->setPartnerCode($partnerCode);
-        $tokens  = [
-            Token::API_PRODUCTS,
-            Token::API_SSO,
-            Token::API_EXCHANGE_RATES,
-            Token::API_SETTINGS,
-            Token::API_EMAIL,
-            Token::API_GRAPHQL
-        ];
-        foreach ($tokens as $token) {
+        foreach (Token::$tokenNames as $token) {
             $this->addApiToken($token);
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add the `APPS` token to the list of tokens that are generated automatically on creating new Nosto account
* Refactor: renamed `HtmlMarkupSerializationHelper::canEncoded` to `HtmlMarkupSerializationHelper::canBeEncoded` 

## Related Issue
closes #191 #192

## Motivation and Context
The `APPS` token was not generated when creating new account

## How Has This Been Tested?
Manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers