### PR TITLE
Feature - Use reflection to support both vlucas/phpdotenv versions 2.x and 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
-### 3.13.0
+## 3.14.0
+* Make DotEnv dependency compatible with 2.x and 3.x versions 
+
+## 3.13.0
 * Add date published to product interface and product object
 
-### 3.12.1
-* Fix GraphQL url
+## 3.12.1
+* Fix GraphQL URL
 
 ## 3.12.0    
 * Add `APPS` token as a default token to be generated on account creation

--- a/src/Helper/IframeHelper.php
+++ b/src/Helper/IframeHelper.php
@@ -68,23 +68,7 @@ final class IframeHelper extends AbstractHelper
         UserInterface $user = null,
         array $params = array()
     ) {
-        $defaultParameters = array(
-            'lang' => strtolower($iframe->getLanguageIsoCode()),
-            'ps_version' => $iframe->getVersionPlatform(),
-            'nt_version' => $iframe->getVersionModule(),
-            'product_pu' => $iframe->getPreviewUrlProduct(),
-            'category_pu' => $iframe->getPreviewUrlCategory(),
-            'search_pu' => $iframe->getPreviewUrlSearch(),
-            'cart_pu' => $iframe->getPreviewUrlCart(),
-            'front_pu' => $iframe->getPreviewUrlFront(),
-            'shop_lang' => strtolower($iframe->getLanguageIsoCodeShop()),
-            'shop_name' => $iframe->getShopName(),
-            'unique_id' => $iframe->getUniqueId(),
-            'fname' => $iframe->getFirstName(),
-            'lname' => $iframe->getLastName(),
-            'email' => $iframe->getEmail(),
-            'modules' => $iframe->getModules()
-        );
+        $defaultParameters = self::getDefaultParams($iframe);
         if ($account instanceof AccountInterface) {
             $missingScopes = $account->getMissingTokens();
             if (!empty($missingScopes)) {
@@ -124,5 +108,30 @@ final class IframeHelper extends AbstractHelper
         }
 
         return $url;
+    }
+
+    /**
+     * @param IframeInterface $iframe
+     * @return array
+     */
+    public static function getDefaultParams(IframeInterface $iframe)
+    {
+        return array(
+            'lang' => strtolower($iframe->getLanguageIsoCode()),
+            'ps_version' => $iframe->getVersionPlatform(),
+            'nt_version' => $iframe->getVersionModule(),
+            'product_pu' => $iframe->getPreviewUrlProduct(),
+            'category_pu' => $iframe->getPreviewUrlCategory(),
+            'search_pu' => $iframe->getPreviewUrlSearch(),
+            'cart_pu' => $iframe->getPreviewUrlCart(),
+            'front_pu' => $iframe->getPreviewUrlFront(),
+            'shop_lang' => strtolower($iframe->getLanguageIsoCodeShop()),
+            'shop_name' => $iframe->getShopName(),
+            'unique_id' => $iframe->getUniqueId(),
+            'fname' => $iframe->getFirstName(),
+            'lname' => $iframe->getLastName(),
+            'email' => $iframe->getEmail(),
+            'modules' => $iframe->getModules()
+        );
     }
 }

--- a/src/Mixins/IframeTrait.php
+++ b/src/Mixins/IframeTrait.php
@@ -36,6 +36,7 @@
 
 namespace Nosto\Mixins;
 
+use Nosto\Helper\IframeHelper;
 use Nosto\Nosto;
 use Nosto\NostoException;
 use Nosto\Operation\InitiateSso;
@@ -59,23 +60,7 @@ trait IframeTrait
     public function buildURL(array $params = array())
     {
         $iframe = self::getIframe();
-        $defaultParameters = array(
-            'lang' => strtolower($iframe->getLanguageIsoCode()),
-            'ps_version' => $iframe->getVersionPlatform(),
-            'nt_version' => $iframe->getVersionModule(),
-            'product_pu' => $iframe->getPreviewUrlProduct(),
-            'category_pu' => $iframe->getPreviewUrlCategory(),
-            'search_pu' => $iframe->getPreviewUrlSearch(),
-            'cart_pu' => $iframe->getPreviewUrlCart(),
-            'front_pu' => $iframe->getPreviewUrlFront(),
-            'shop_lang' => strtolower($iframe->getLanguageIsoCodeShop()),
-            'shop_name' => $iframe->getShopName(),
-            'unique_id' => $iframe->getUniqueId(),
-            'fname' => $iframe->getFirstName(),
-            'lname' => $iframe->getLastName(),
-            'email' => $iframe->getEmail(),
-            'modules' => $iframe->getModules()
-        );
+        $defaultParameters = IframeHelper::getDefaultParams($iframe);
 
         $account = self::getAccount();
         if ($account instanceof AccountInterface) {

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -40,7 +40,7 @@ try {
     if ($params[0]->getName() === 'path' && $params[1]->getName() === 'file') {
         $dotenv = new Dotenv\Dotenv(dirname(__FILE__));
     } else {
-        $dotenv = Dotenv\Dotenv::create(dirname(__FILE__));
+        $dotenv = Dotenv\Dotenv::create(dirname(__FILE__)); // @phan-suppress-current-line PhanUndeclaredStaticMethod
     }
     $dotenv->load();
 } catch (Exception $e) {

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -35,7 +35,13 @@
  */
 
 try {
-    $dotenv = new Dotenv\Dotenv(dirname(__FILE__));
+    $reflectDotEnv = new ReflectionMethod('Dotenv\Dotenv', '__construct');
+    $params = $reflectDotEnv->getParameters();
+    if ($params[0]->getName() === 'path' && $params[1]->getName() === 'file') {
+        $dotenv = new Dotenv\Dotenv(dirname(__FILE__));
+    } else {
+        $dotenv = Dotenv\Dotenv::create(dirname(__FILE__));
+    }
     $dotenv->load();
 } catch (Exception $e) {
     // Could not load ENV using defaults

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -35,8 +35,18 @@
  */
 
 date_default_timezone_set('Europe/Helsinki');
-$dotenv = new Dotenv\Dotenv(dirname(__FILE__));
-$dotenv->overload();
+try {
+    $reflectDotEnv = new ReflectionMethod('Dotenv\Dotenv', '__construct');
+    $params = $reflectDotEnv->getParameters();
+    if ($params[0]->getName() === 'path' && $params[1]->getName() === 'file') {
+        $dotenv = new Dotenv\Dotenv(dirname(__FILE__));
+    } else {
+        $dotenv = Dotenv\Dotenv::create(dirname(__FILE__));
+    }
+    $dotenv->overload();
+} catch (Exception $e) {
+    // Could not load ENV using defaults
+}
 
 require_once(dirname(__FILE__) . '/../vendor/autoload.php');
 Nosto\Request\Http\HttpRequest::buildUserAgent('PHPUnit', '1.0.0', '1.0.0');

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -46,6 +46,8 @@ try {
     $dotenv->overload();
 } catch (Exception $e) {
     // Could not load ENV using defaults
+    /** @noinspection PhpUnhandledExceptionInspection */
+    throw $e;
 }
 
 require_once(dirname(__FILE__) . '/../vendor/autoload.php');


### PR DESCRIPTION
## Description
Use reflection to support both vlucas/phpdotenv versions 2.x and 3.x

## Related Issue
Fixes #208 

## Motivation and Context
Shopware is now using the version 3.x of phpdotenv dependency, whereas Magento 2 is still using version 2.6. This makes the dependency compatible with both versions

## How Has This Been Tested?
Deployed to Plugintest with Shopware, the invalid constructor argument error is now fixed.

## Checklist:

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
