### PR TITLE
Feature/add inventory level SKU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+## 3.15.0
+* Add inventory level data to SKUs
+
 ## 3.14.1
 * Set vlucas/phpdotenv to be compatible with any version below 3.0
 

--- a/src/Object/Product/Sku.php
+++ b/src/Object/Product/Sku.php
@@ -42,6 +42,7 @@ use Nosto\Types\HtmlEncodableInterface;
 use Nosto\Types\MarkupableInterface;
 use Nosto\Types\Product\SkuInterface;
 use Nosto\Types\Product\ProductInterface;
+use Nosto\Types\SanitizableInterface;
 
 /**
  * Model for sku information
@@ -49,7 +50,8 @@ use Nosto\Types\Product\ProductInterface;
 class Sku extends AbstractObject implements
     SkuInterface,
     MarkupableInterface,
-    HtmlEncodableInterface
+    HtmlEncodableInterface,
+    SanitizableInterface
 {
     use HtmlEncoderTrait;
 

--- a/src/Object/Product/Sku.php
+++ b/src/Object/Product/Sku.php
@@ -116,6 +116,11 @@ class Sku extends AbstractObject implements
     private $customFields = array();
 
     /**
+     * @var int|null product stock level
+     */
+    private $inventoryLevel;
+
+    /**
      * @inheritdoc
      */
     public function getId()
@@ -308,5 +313,34 @@ class Sku extends AbstractObject implements
     public function getMarkupKey()
     {
         return 'nosto_sku';
+    }
+
+    /**
+     * Returns the inventory stock level
+     *
+     * @return int|null
+     */
+    public function getInventoryLevel()
+    {
+        return $this->inventoryLevel;
+    }
+
+    /**
+     * @param int|null $inventoryLevel
+     */
+    public function setInventoryLevel($inventoryLevel)
+    {
+        $this->inventoryLevel = $inventoryLevel;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function sanitize()
+    {
+        $sanitized = clone $this;
+        $sanitized->setInventoryLevel(null);
+
+        return $sanitized;
     }
 }

--- a/tests/_support/MockSku.php
+++ b/tests/_support/MockSku.php
@@ -51,6 +51,7 @@ class MockSku extends Sku
         $this->setUrl('http://my.shop.com/products/test_product.html');
         $this->setName('Test Product');
         $this->setImageUrl('http://my.shop.com/images/test_product.jpg');
+        $this->setInventoryLevel(20);
     }
 
     public function __get($name)

--- a/tests/unit/Helper/SerializationHelperTest.php
+++ b/tests/unit/Helper/SerializationHelperTest.php
@@ -41,6 +41,7 @@ use Codeception\TestCase\Test;
 use Nosto\Helper\SerializationHelper;
 use Nosto\Test\Support\MockProduct;
 use Nosto\Test\Support\MockProductWithSku;
+use Nosto\Test\Support\MockSku;
 
 class SerializationHelperTest extends Test
 {
@@ -151,6 +152,16 @@ class SerializationHelperTest extends Test
     public function testObjectWithSkus()
     {
         $object = new MockProductWithSku();
-        $this->assertEquals('{"url":"http:\/\/my.shop.com\/products\/test_product.html","product_id":1,"name":"Test Product","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","price":99.99,"list_price":110.99,"price_currency_code":"USD","availability":"InStock","categories":["\/Mens","\/Mens\/Shoes"],"description":"This is a full description","brand":"Super Brand","variation_id":"USD","supplier_cost":22.33,"inventory_level":50,"review_count":99,"rating_value":2.5,"alternate_image_urls":["http:\/\/shop.com\/product_alt.jpg"],"condition":"Used","gtin":"gtin","tag1":["first"],"tag2":["second"],"tag3":["third"],"google_category":"All","skus":[{"id":100,"name":"Test Product","price":99.99,"list_price":110.99,"url":"http:\/\/my.shop.com\/products\/test_product.html","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","gtin":"gtin","availability":"InStock"},{"id":100,"name":"Test Product","price":99.99,"list_price":110.99,"url":"http:\/\/my.shop.com\/products\/test_product.html","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","gtin":"gtin","availability":"InStock","custom_fields":{"noSnakeCase":"value"}},{"id":100,"name":"Test Product","price":99.99,"list_price":110.99,"url":"http:\/\/my.shop.com\/products\/test_product.html","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","gtin":"gtin","availability":"InStock","custom_fields":{"\u00e5\u00e4\u00f6":"\u00e5\u00e4\u00f6"}}],"variations":[],"date_published":"2013-03-05"}', SerializationHelper::serialize($object));
+        $this->assertEquals('{"url":"http:\/\/my.shop.com\/products\/test_product.html","product_id":1,"name":"Test Product","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","price":99.99,"list_price":110.99,"price_currency_code":"USD","availability":"InStock","categories":["\/Mens","\/Mens\/Shoes"],"description":"This is a full description","brand":"Super Brand","variation_id":"USD","supplier_cost":22.33,"inventory_level":50,"review_count":99,"rating_value":2.5,"alternate_image_urls":["http:\/\/shop.com\/product_alt.jpg"],"condition":"Used","gtin":"gtin","tag1":["first"],"tag2":["second"],"tag3":["third"],"google_category":"All","skus":[{"id":100,"name":"Test Product","price":99.99,"list_price":110.99,"url":"http:\/\/my.shop.com\/products\/test_product.html","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","gtin":"gtin","availability":"InStock","inventory_level":20},{"id":100,"name":"Test Product","price":99.99,"list_price":110.99,"url":"http:\/\/my.shop.com\/products\/test_product.html","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","gtin":"gtin","availability":"InStock","custom_fields":{"noSnakeCase":"value"},"inventory_level":20},{"id":100,"name":"Test Product","price":99.99,"list_price":110.99,"url":"http:\/\/my.shop.com\/products\/test_product.html","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","gtin":"gtin","availability":"InStock","custom_fields":{"\u00e5\u00e4\u00f6":"\u00e5\u00e4\u00f6"},"inventory_level":20}],"variations":[],"date_published":"2013-03-05"}', SerializationHelper::serialize($object));
+    }
+
+    /**
+     * Tests that an object SKUs are serialized to HTML correctly
+     */
+    public function testObjectWithSkusAreSanitized()
+    {
+        $object = new MockSku();
+        $object = $object->sanitize();
+        $this->assertEquals('{"id":100,"name":"Test Product","price":99.99,"list_price":110.99,"url":"http:\/\/my.shop.com\/products\/test_product.html","image_url":"http:\/\/my.shop.com\/images\/test_product.jpg","gtin":"gtin","availability":"InStock"}', SerializationHelper::serialize($object));
     }
 }

--- a/tests/unit/Helper/SerializationHelperTest.php
+++ b/tests/unit/Helper/SerializationHelperTest.php
@@ -158,7 +158,7 @@ class SerializationHelperTest extends Test
     /**
      * Tests that an object SKUs are serialized to HTML correctly
      */
-    public function testObjectWithSkusAreSanitized()
+    public function testSkuIsSanitized()
     {
         $object = new MockSku();
         $object = $object->sanitize();


### PR DESCRIPTION
## Description
Amend inventory level on SKU products as well.

## Related Issue
Closes #174 

## Motivation and Context
We already had the field available on Playcart, but the extensions are not sending the SKU level. This makes it available for the extensions to send this extra field.

## How Has This Been Tested?
Tested with Magento 1 extension. See [this PR](https://github.com/Nosto/nosto-magento/pull/525).

## Documentation:
N/A

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
