### PR TITLE
Hotfix/4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+##  4.0.2
+* Remove redundant fields from category recommendation GraphQL query - only leave the productId
+
 ##  4.0.1
 * Fix category merchandising GraphQL query setting wrong preview value 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to Semantic Versioning (http://semver.org/).
 
 ##  4.0.2
 * Remove redundant fields from category recommendation GraphQL query - only leave the productId
+* Avoid redundant product API calls if no products have been added to the collection to be updated or deleted
 
 ##  4.0.1
 * Fix category merchandising GraphQL query setting wrong preview value 

--- a/src/Operation/DeleteProduct.php
+++ b/src/Operation/DeleteProduct.php
@@ -90,6 +90,9 @@ class DeleteProduct extends AbstractAuthenticatedOperation
             $this->account->getName(),
             $this->activeDomain
         );
+        if (empty($this->productIds)) {
+            return true;
+        }
         $response = $request->post($this->productIds);
         return $request->getResultHandler()->parse($response);
     }

--- a/src/Operation/Recommendation/CategoryMerchandising.php
+++ b/src/Operation/Recommendation/CategoryMerchandising.php
@@ -97,10 +97,6 @@ class CategoryMerchandising extends AbstractRecommendation
               }) {
                 primary {
                   productId
-                  priceText
-                  name
-                  imageUrl
-                  url
                 }
                 batchToken
                 totalPrimaryCount

--- a/src/Operation/UpsertProduct.php
+++ b/src/Operation/UpsertProduct.php
@@ -103,6 +103,9 @@ class UpsertProduct extends AbstractAuthenticatedOperation
             $this->account->getName(),
             $this->activeDomain
         );
+        if ($this->collection->count() === 0) {
+            return true;
+        }
         $response = $request->post($this->collection);
         return $request->getResultHandler()->parse($response);
     }


### PR DESCRIPTION
* Remove redundant fields from category recommendation GraphQL query - only leave the productId
* Avoid redundant product API calls if no products have been added to the collection to be updated or deleted

## Description
* Check the collection size before making the product upsert or delete
* Remove redundant fields from CMP graphql call 

## Related Issue
#227 
#230 

## Motivation and Context
* Reduce the graphql response size in order to keep the response times low
* Reduce the amount of redundant / empty API calls 

## How Has This Been Tested?
* Tested locally with product updates and CMP extension 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
