### PR TITLE
Update PHPCompatibility and other PHPCS related fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -61,19 +61,11 @@
 
     <target name="phpcbf">
         <exec executable="./vendor/bin/phpcbf" passthru="true">
-            <arg value="--colors"/>
-            <arg value="--report-width=auto"/>
-            <arg value="--standard=ruleset.xml"/>
-            <arg value="."/>
         </exec>
     </target>
 
     <target name="phpcs" depends="phpcbf">
         <exec executable="./vendor/bin/phpcs" passthru="true">
-            <arg value="--colors"/>
-            <arg value="--report-width=auto"/>
-            <arg value="--standard=ruleset.xml"/>
-            <arg value="."/>
         </exec>
     </target>
 

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,14 @@
   "require-dev": {
     "codeception/specify": "^0.4.6",
     "phpmd/phpmd": "^2.6",
-    "squizlabs/php_codesniffer": "^2.6",
     "sebastian/phpcpd": "^3.0",
     "phing/phing": "2.*",
     "codeception/c3": "^2.0",
     "symfony/console": "3.*",
-    "wimg/php-compatibility": "^8.0",
-    "phan/phan": "^1.2"
+    "phan/phan": "^1.2",
+    "squizlabs/php_codesniffer": "^3.5",
+    "phpcompatibility/php-compatibility": "^9.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
   },
   "repositories": [
     {
@@ -39,9 +40,5 @@
     "ext-json": "*",
     "ext-curl": "*",
     "codeception/base": "3.1.1"
-  },
-  "scripts-dev": {
-    "post-install-cmd": "if [ -f ./vendor/bin/phpcs ]; then \"vendor/bin/phpcs\" --config-set installed_paths vendor/wimg/php-compatibility; fi",
-    "post-update-cmd" : "if [ -f ./vendor/bin/phpcs ]; then \"vendor/bin/phpcs\" --config-set installed_paths vendor/wimg/php-compatibility; fi"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d1629f35ae299cc44e240c159e06f28",
+    "content-hash": "680094f0525485ffee5c241bf79fa7a7",
     "packages": [
         {
             "name": "behat/gherkin",
@@ -2685,6 +2685,72 @@
             "time": "2019-11-06T16:40:04+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "^2|^3"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2018-10-26T13:21:45+00:00"
+        },
+        {
             "name": "felixfbecker/advanced-json-rpc",
             "version": "v3.0.4",
             "source": {
@@ -3015,6 +3081,64 @@
             "time": "2018-01-25T13:18:09+00:00"
         },
         {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-11-15T04:12:02+00:00"
+        },
+        {
             "name": "phpmd/phpmd",
             "version": "2.7.0",
             "source": {
@@ -3282,63 +3406,36 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "version": "3.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3351,12 +3448,12 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2019-12-04T04:46:47+00:00"
         },
         {
             "name": "symfony/config",
@@ -3642,60 +3739,6 @@
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
             "time": "2017-06-30T11:53:12+00:00"
-        },
-        {
-            "name": "wimg/php-compatibility",
-            "version": "8.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                }
-            ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "abandoned": "phpcompatibility/php-compatibility",
-            "time": "2018-07-17T13:42:26+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -35,18 +35,53 @@
   ~
   -->
 
-<!--suppress XmlUnboundNsPrefix -->
-<ruleset name="NostoPHPSDK">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="NostoPHPSDK"
+    xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
     <description>Nosto PHP SDK coding standards</description>
+
+    <!--
+    #############################################################################
+    COMMAND LINE ARGUMENTS
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
+    #############################################################################
+    -->
+
+    <file>.</file>
+
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/tests/*</exclude-pattern>
+    <exclude-pattern>*/phpseclib/*</exclude-pattern>
+
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="./"/>
+
+    <!-- Check up to 8 files simultaneously. -->
+    <arg name="parallel" value="8"/>
+
+    <!-- Show coloured output. -->
+    <arg name="colors"/>
+
+    <!-- Determine the report width automatically. -->
+    <arg name="report-width" value="auto"/>
+
+    <!--
+    #############################################################################
+    RULES
+    #############################################################################
+    -->
+
     <rule ref="PSR1"/>
     <rule ref="PSR2">
         <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
         <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
     </rule>
+
     <rule ref="PHPCompatibility"/>
     <config name="testVersion" value="5.4-"/>
-    <exclude-pattern>*/vendor/*</exclude-pattern>
-    <exclude-pattern>*/tests/*</exclude-pattern>
-    <exclude-pattern>*/phpseclib/*</exclude-pattern>
-    <exclude-pattern>*.js</exclude-pattern>
+
 </ruleset>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -43,9 +43,8 @@
         <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
         <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
     </rule>
-    <config name="installed_paths" value="vendor/wimg/php-compatibility/" />
     <rule ref="PHPCompatibility"/>
-    <config name="testVersion" value="5.4"/>
+    <config name="testVersion" value="5.4-"/>
     <exclude-pattern>*/vendor/*</exclude-pattern>
     <exclude-pattern>*/tests/*</exclude-pattern>
     <exclude-pattern>*/phpseclib/*</exclude-pattern>

--- a/src/Helper/OAuthHelper.php
+++ b/src/Helper/OAuthHelper.php
@@ -46,7 +46,7 @@ use Nosto\Types\OAuthInterface;
 class OAuthHelper extends AbstractHelper
 {
 
-    const PATH_AUTH = '?client_id={cid}&redirect_uri={uri}&response_type=code&scope={sco}&lang={iso}'; // @codingStandardsIgnoreLine
+    const PATH_AUTH = '?client_id={cid}&redirect_uri={uri}&response_type=code&scope={sco}&lang={iso}';
 
     /**
      * Returns the authorize url to the oauth2 server.

--- a/src/Mixins/IframeTrait.php
+++ b/src/Mixins/IframeTrait.php
@@ -106,19 +106,19 @@ trait IframeTrait
      *
      * @return IframeInterface the iframe params with which to load the iframe
      */
-    public abstract function getIframe();
+    abstract public function getIframe();
 
     /**
      * Returns the current for which to load the IFrame
      *
      * @return UserInterface the current user for which to load the iframe
      */
-    public abstract function getUser();
+    abstract public function getUser();
 
     /**
      * Returns the account for which to load the IFrame
      *
      * @return AccountInterface the account for which to load the iframe
      */
-    public abstract function getAccount();
+    abstract public function getAccount();
 }

--- a/src/Mixins/OauthTrait.php
+++ b/src/Mixins/OauthTrait.php
@@ -46,7 +46,7 @@ use Nosto\Types\Signup\AccountInterface;
 trait OauthTrait
 {
 
-    public final function connect()
+    final public function connect()
     {
         if (($code = self::getParam('code')) !== null) {
             try {
@@ -101,15 +101,15 @@ trait OauthTrait
         }
     }
 
-    public abstract function getParam($name);
+    abstract public function getParam($name);
 
-    public abstract function getMeta();
+    abstract public function getMeta();
 
-    public abstract function save(AccountInterface $account);
+    abstract public function save(AccountInterface $account);
 
-    public abstract function redirect(array $params);
+    abstract public function redirect(array $params);
 
-    public abstract function logError(Exception $e);
+    abstract public function logError(Exception $e);
 
-    public abstract function notFound();
+    abstract public function notFound();
 }

--- a/src/Nosto.php
+++ b/src/Nosto.php
@@ -61,7 +61,7 @@ class Nosto
     const DEFAULT_NOSTO_OAUTH_BASE_URL = 'https://my.nosto.com/oauth';
     const DEFAULT_NOSTO_API_BASE_URL = 'https://api.nosto.com';
     const DEFAULT_NOSTO_GRAPHQL_BASE_URL = 'https://api.nosto.com';
-    const DEFAULT_NOSTO_IFRAME_ORIGIN_REGEXP = '(https:\/\/(.*)\.hub\.nosto\.com)|(https:\/\/my\.nosto\.com)'; //codingStandardsIgnoreLine
+    const DEFAULT_NOSTO_IFRAME_ORIGIN_REGEXP = '(https:\/\/(.*)\.hub\.nosto\.com)|(https:\/\/my\.nosto\.com)';
 
     const URL_PARAM_MESSAGE_TYPE = 'message_type';
     const URL_PARAM_MESSAGE_CODE = 'message_code';

--- a/src/Operation/AbstractGraphQLOperation.php
+++ b/src/Operation/AbstractGraphQLOperation.php
@@ -134,5 +134,4 @@ abstract class AbstractGraphQLOperation extends AbstractOperation
     {
         return GraphqlRequest::PATH_GRAPH_QL;
     }
-
 }

--- a/src/Operation/DeleteProduct.php
+++ b/src/Operation/DeleteProduct.php
@@ -129,5 +129,4 @@ class DeleteProduct extends AbstractAuthenticatedOperation
     {
         return ApiRequest::PATH_PRODUCTS_DISCONTINUE;
     }
-
 }

--- a/src/Operation/OAuth/AuthorizationCode.php
+++ b/src/Operation/OAuth/AuthorizationCode.php
@@ -50,7 +50,8 @@ use Nosto\Result\Api\JsonResultHandler;
  */
 class AuthorizationCode extends AbstractOperation
 {
-    const PATH_TOKEN = '/token?code={cod}&client_id={cid}&client_secret={sec}&redirect_uri={uri}&grant_type=authorization_code'; // @codingStandardsIgnoreLine
+    // phpcs:ignore Generic.Files.LineLength.TooLong
+    const PATH_TOKEN = '/token?code={cod}&client_id={cid}&client_secret={sec}&redirect_uri={uri}&grant_type=authorization_code';
 
     /**
      * @var string the client id the identify this application to the oauth2 server.

--- a/src/Operation/OAuth/AuthorizationCode.php
+++ b/src/Operation/OAuth/AuthorizationCode.php
@@ -156,5 +156,4 @@ class AuthorizationCode extends AbstractOperation
     {
         return new JsonResultHandler();
     }
-
 }

--- a/src/Operation/OAuth/ExchangeTokens.php
+++ b/src/Operation/OAuth/ExchangeTokens.php
@@ -118,5 +118,4 @@ class ExchangeTokens extends AbstractOperation
     {
         return HttpRequest::PATH_OAUTH_SYNC;
     }
-
 }

--- a/src/Result/Api/ApiResultHandler.php
+++ b/src/Result/Api/ApiResultHandler.php
@@ -52,5 +52,4 @@ abstract class ApiResultHandler extends ResultHandler
      * @return string|array
      */
     abstract protected function parseAPIResult(HttpResponse $response);
-
 }

--- a/src/Result/Api/GeneralPurposeResultHandler.php
+++ b/src/Result/Api/GeneralPurposeResultHandler.php
@@ -47,5 +47,4 @@ class GeneralPurposeResultHandler extends ApiResultHandler
     {
         return true;
     }
-
 }

--- a/src/Util/Time.php
+++ b/src/Util/Time.php
@@ -36,7 +36,6 @@
 
 namespace Nosto\Util;
 
-
 class Time
 {
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### PHPCS/Composer: update PHPCompatibility

Composer:
* `wimg/php-compatibility` has been abandoned for nearly a year. Use `phpcompatibility/php-compatibility` instead.
* Use the latest version of PHPCompatibility.
    You were missing out on a lot of new checks, including the checks to make sure your code is compatible with the upcoming PHP 7.4.
* Use the latest version of PHP_CodeSniffer.
    Version 3.x includes new features like parallel scanning of files and altogether contains lots of bug fixes, so using the latest version is a good idea and will give more reliable results.
* Add the DealerDirect Composer PHPCS plugin.
    This plugin will handle setting the PHPCS `installed_paths` automatically.
    This also allows to remove the unsupported/unused `scripts-dev` section from the Composer file, as well as the `installed_paths` setting in the ruleset file.

PHPCS ruleset:
* Actually check for cross-version compatibility.
    You were currently just checking if the code was compatible with PHP 5.4, not with _PHP 5.4 and above_.

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/squizlabs/php_codesniffer/releases
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases

### PHPCS: improve ruleset

* Rename the ruleset to `phpcs.xml.dist` which will allow PHPCS to automatically pick up on it.
    No need to pass the `--standard=...` command-line argument anymore.
* Add the XSD schema for PHPCS to the ruleset.
* Move the other command-line arguments from the `build.xml` script to the ruleset.
* Enable the PHPCS 3.x `basepath` and `parallel` options.
* Document the ruleset.

### CS: apply CS fixes

### CS: update/remove ignore annotations

Looks like two are no longer necessary, probably due to bugs fixed, while one should be updated to the new PHPCS 3.2+ selective ignore annotations.

## Related Issue

#234

## Motivation and Context
See above description of the individual commits.

The remaining 37 issues are actually one and the same issue which is the directory called `Object` which has then been translated to be part of the `namespace` for 37 classes.

`object` is a reserved keyword in PHP and should not be used in namespaces.

As changing this would constitute a BC-break, I am not addressing this in this PR, but leaving a decision on how to solve this to the developers of this project.

## How Has This Been Tested?
Running PHPCS with the updated dependencies and ruleset locally.


## Documentation:
_N/A_

## Checklist:
- [x] My code follows the code style of this project. _That's what this PR is all above and it fixes things previously left unfixed_
- [ ] ~~I have updated the documentation accordingly.~~ _N/A_
- [ ] ~~All new and existing tests passed.~~ _N/A_
- [ ] ~~I have assigned the correct milestone or created one if non-existent.~~ _N/A, not possible for outside contributors_
- [ ] ~~I have correctly labeled this pull request.~~ _N/A, not possible for outside contributors_
- [x] I have linked the corresponding issue in this description.
- [ ] ~~I have updated the corresponding Jira ticket.~~ _N/A_
- [ ] ~~I have requested a review from at least 2 reviewers~~ _N/A, not possible for outside contributors_
- [x] I have checked the base branch of this pull request
- [ ] ~~I have checked my code for any possible security vulnerabilities~~ _N/A_

(pff... makes one wonder whether you actually welcome contributions from outsiders...)
