### PR TITLE
Add a null check for the customer object in order confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
 ## 4.0.7
-* Add a null check for customer before trying to populate customer data in order confirmation API call
+* Add a null check for customer before trying to populate customer data in order confirmation graphql call
 
 ## 4.0.6
 * Support faceting and pagination in Category Merchandising query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+## 4.0.7
+* Add a null check for customer before trying to populate customer data in order confirmation API call
+
 ## 4.0.6
 * Support faceting and pagination in Category Merchandising query
 

--- a/src/Operation/Order/OrderCreate.php
+++ b/src/Operation/Order/OrderCreate.php
@@ -82,7 +82,7 @@ class OrderCreate extends AbstractGraphQLOperation
     }
 
     /**
-     * @return BuyerInterface
+     * @return BuyerInterface|null
      */
     public function getCustomer()
     {
@@ -153,10 +153,10 @@ class OrderCreate extends AbstractGraphQLOperation
             mutation(
                 \$by: LookupParams!,
                 \$customerIdentifier: String!
-                \$firstname:String!,
-                \$lastname: String!,
-                \$email: String!,
-                \$marketingPermission: Boolean!,
+                \$firstname:String,
+                \$lastname: String,
+                \$email: String,
+                \$marketingPermission: Boolean,
                 \$orderNumber: String!,
                 \$orderStatus: String!,
                 \$paymentProvider: String!,
@@ -199,17 +199,21 @@ QUERY;
         $array = [
             'by' => $this->identifierMethod,
             'customerIdentifier' => $this->identifierString,
-            'firstname' => $this->getCustomer()->getFirstName(),
-            'lastname' => $this->getCustomer()->getLastName(),
-            'email' => $this->getCustomer()->getEmail(),
-            'marketingPermission' => $this->getCustomer()->getMarketingPermission(),
             'orderNumber' => $this->getOrderNumber(),
             'orderStatus' => $this->getStatusCode(),
             'paymentProvider' => $this->getPaymentProvider(),
             'ref' => $this->getOrderReference(),
             'purchasedItems' => $this->getPurchasedItems(),
         ];
-
+        $buyer = $this->getCustomer();
+        if ($buyer !== null) {
+            $array = array_merge($array, [
+                'firstname' => $buyer->getFirstName(),
+                'lastname' => $buyer->getLastName(),
+                'email' => $buyer->getEmail(),
+                'marketingPermission' => $buyer->getMarketingPermission()
+            ]);
+        }
         return $array;
     }
 }

--- a/src/Types/Order/OrderInterface.php
+++ b/src/Types/Order/OrderInterface.php
@@ -70,7 +70,7 @@ interface OrderInterface
     /**
      * The buyer info of the user who placed the OrderConfirm.
      *
-     * @return BuyerInterface the meta data model.
+     * @return BuyerInterface|null the meta data model.
      */
     public function getCustomer();
 


### PR DESCRIPTION
## Description
Add a null check for the order confirmation API call variables. 

## Related Issue
#250

## Motivation and Context
Order confirmation throws a fatal error if customer is null.

## How Has This Been Tested?
Tested with Magento 2 by forcing the customer to be null.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
