### PR TITLE
Add skipVCEvent to the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to Semantic Versioning (http://semver.org/).
 
 ## not released
 * Introduce object for sort order tagging
+* Add skipVCEvent to CMP graphql query
 
 ## 4.0.11
 * Add exception class for missing APPS token

--- a/src/Operation/Recommendation/CategoryMerchandising.php
+++ b/src/Operation/Recommendation/CategoryMerchandising.php
@@ -113,7 +113,8 @@ class CategoryMerchandising extends AbstractRecommendation
                 maxProducts: \$limit,
                 skipPages: \$skipPages,
                 include: \$includeFilters,
-                exclude: \$excludeFilters
+                exclude: \$excludeFilters,
+                skipVCEvent: true
               ) {
                 primary {
                   productId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add skipVCEvent to the graphql query in order not to create a VC event when making the query. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
