### PR TITLE
Replace short array syntax instead

### DIFF
--- a/src/Helper/ArrayHelper.php
+++ b/src/Helper/ArrayHelper.php
@@ -63,7 +63,7 @@ class ArrayHelper extends AbstractHelper
      */
     public static function isAssoc(array $arr)
     {
-        if (array() === $arr) {
+        if ([] === $arr) {
             return false;
         }
         return array_keys($arr) !== range(0, count($arr) - 1);

--- a/src/Helper/CurrencyHelper.php
+++ b/src/Helper/CurrencyHelper.php
@@ -49,1082 +49,1082 @@ final class CurrencyHelper extends AbstractHelper
     /**
      * @var array currency data keyed on the currencies ISO 4217 codes.
      */
-    private static $data = array(
-        'AED' => array(
+    private static $data = [
+        'AED' => [
             'name' => 'UAE Dirham',
             'numericCode' => 784,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'AFN' => array(
+        ],
+        'AFN' => [
             'name' => 'Afghani',
             'numericCode' => 971,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ALL' => array(
+        ],
+        'ALL' => [
             'name' => 'Lek',
             'numericCode' => 8,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'AMD' => array(
+        ],
+        'AMD' => [
             'name' => 'Armenian Dram',
             'numericCode' => 51,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ANG' => array(
+        ],
+        'ANG' => [
             'name' => 'Netherlands Antillean Guilder',
             'numericCode' => 532,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'AOA' => array(
+        ],
+        'AOA' => [
             'name' => 'Kwanza',
             'numericCode' => 973,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ARS' => array(
+        ],
+        'ARS' => [
             'name' => 'Argentine Peso',
             'numericCode' => 32,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'AUD' => array(
+        ],
+        'AUD' => [
             'name' => 'Australian Dollar',
             'numericCode' => 36,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'AWG' => array(
+        ],
+        'AWG' => [
             'name' => 'Aruban Florin',
             'numericCode' => 533,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'AZN' => array(
+        ],
+        'AZN' => [
             'name' => 'Azerbaijanian Manat',
             'numericCode' => 944,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BAM' => array(
+        ],
+        'BAM' => [
             'name' => 'Convertible Mark',
             'numericCode' => 977,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BBD' => array(
+        ],
+        'BBD' => [
             'name' => 'Barbados Dollar',
             'numericCode' => 52,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BDT' => array(
+        ],
+        'BDT' => [
             'name' => 'Taka',
             'numericCode' => 50,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BGN' => array(
+        ],
+        'BGN' => [
             'name' => 'Bulgarian Lev',
             'numericCode' => 975,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BHD' => array(
+        ],
+        'BHD' => [
             'name' => 'Bahraini Dinar',
             'numericCode' => 48,
             'fractionDecimals' => 3,
             'fractionUnit' => 1000,
-        ),
-        'BIF' => array(
+        ],
+        'BIF' => [
             'name' => 'Burundi Franc',
             'numericCode' => 108,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'BMD' => array(
+        ],
+        'BMD' => [
             'name' => 'Bermudian Dollar',
             'numericCode' => 60,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BND' => array(
+        ],
+        'BND' => [
             'name' => 'Brunei Dollar',
             'numericCode' => 96,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BOB' => array(
+        ],
+        'BOB' => [
             'name' => 'Boliviano',
             'numericCode' => 68,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BOV' => array(
+        ],
+        'BOV' => [
             'name' => 'Mvdol',
             'numericCode' => 984,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BRL' => array(
+        ],
+        'BRL' => [
             'name' => 'Brazilian Real',
             'numericCode' => 986,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BSD' => array(
+        ],
+        'BSD' => [
             'name' => 'Bahamian Dollar',
             'numericCode' => 44,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BTN' => array(
+        ],
+        'BTN' => [
             'name' => 'Ngultrum',
             'numericCode' => 64,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BTC' => array(
+        ],
+        'BTC' => [
             'name' => 'Bitcoin',
             'numericCode' => 00,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BWP' => array(
+        ],
+        'BWP' => [
             'name' => 'Pula',
             'numericCode' => 72,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'BYR' => array(
+        ],
+        'BYR' => [
             'name' => 'Belarussian Ruble',
             'numericCode' => 974,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'BZD' => array(
+        ],
+        'BZD' => [
             'name' => 'Belize Dollar',
             'numericCode' => 84,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CAD' => array(
+        ],
+        'CAD' => [
             'name' => 'Canadian Dollar',
             'numericCode' => 124,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CDF' => array(
+        ],
+        'CDF' => [
             'name' => 'Congolese Franc',
             'numericCode' => 976,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CHE' => array(
+        ],
+        'CHE' => [
             'name' => 'WIR Euro',
             'numericCode' => 947,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CHF' => array(
+        ],
+        'CHF' => [
             'name' => 'Swiss Franc',
             'numericCode' => 756,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CHW' => array(
+        ],
+        'CHW' => [
             'name' => 'WIR Franc',
             'numericCode' => 948,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CLF' => array(
+        ],
+        'CLF' => [
             'name' => 'Unidades de fomento',
             'numericCode' => 990,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'CLP' => array(
+        ],
+        'CLP' => [
             'name' => 'Chilean Peso',
             'numericCode' => 152,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'CNY' => array(
+        ],
+        'CNY' => [
             'name' => 'Yuan Renminbi',
             'numericCode' => 156,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'COP' => array(
+        ],
+        'COP' => [
             'name' => 'Colombian Peso',
             'numericCode' => 170,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'COU' => array(
+        ],
+        'COU' => [
             'name' => 'Unidad de Valor Real',
             'numericCode' => 970,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CRC' => array(
+        ],
+        'CRC' => [
             'name' => 'Costa Rican Colon',
             'numericCode' => 188,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CUC' => array(
+        ],
+        'CUC' => [
             'name' => 'Peso Convertible',
             'numericCode' => 931,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CUP' => array(
+        ],
+        'CUP' => [
             'name' => 'Cuban Peso',
             'numericCode' => 192,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CVE' => array(
+        ],
+        'CVE' => [
             'name' => 'Cape Verde Escudo',
             'numericCode' => 132,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'CZK' => array(
+        ],
+        'CZK' => [
             'name' => 'Czech Koruna',
             'numericCode' => 203,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'DJF' => array(
+        ],
+        'DJF' => [
             'name' => 'Djibouti Franc',
             'numericCode' => 262,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'DKK' => array(
+        ],
+        'DKK' => [
             'name' => 'Danish Krone',
             'numericCode' => 208,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'DOP' => array(
+        ],
+        'DOP' => [
             'name' => 'Dominican Peso',
             'numericCode' => 214,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'DZD' => array(
+        ],
+        'DZD' => [
             'name' => 'Algerian Dinar',
             'numericCode' => 12,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'EGP' => array(
+        ],
+        'EGP' => [
             'name' => 'Egyptian Pound',
             'numericCode' => 818,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ERN' => array(
+        ],
+        'ERN' => [
             'name' => 'Nakfa',
             'numericCode' => 232,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ETB' => array(
+        ],
+        'ETB' => [
             'name' => 'Ethiopian Birr',
             'numericCode' => 230,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'EUR' => array(
+        ],
+        'EUR' => [
             'name' => 'Euro',
             'numericCode' => 978,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'FJD' => array(
+        ],
+        'FJD' => [
             'name' => 'Fiji Dollar',
             'numericCode' => 242,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'FKP' => array(
+        ],
+        'FKP' => [
             'name' => 'Falkland Islands Pound',
             'numericCode' => 238,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'GBP' => array(
+        ],
+        'GBP' => [
             'name' => 'Pound Sterling',
             'numericCode' => 826,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'GEL' => array(
+        ],
+        'GEL' => [
             'name' => 'Lari',
             'numericCode' => 981,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'GHS' => array(
+        ],
+        'GHS' => [
             'name' => 'Ghana Cedi',
             'numericCode' => 936,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'GIP' => array(
+        ],
+        'GIP' => [
             'name' => 'Gibraltar Pound',
             'numericCode' => 292,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'GMD' => array(
+        ],
+        'GMD' => [
             'name' => 'Dalasi',
             'numericCode' => 270,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'GNF' => array(
+        ],
+        'GNF' => [
             'name' => 'Guinea Franc',
             'numericCode' => 324,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'GTQ' => array(
+        ],
+        'GTQ' => [
             'name' => 'Quetzal',
             'numericCode' => 320,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'GYD' => array(
+        ],
+        'GYD' => [
             'name' => 'Guyana Dollar',
             'numericCode' => 328,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'HKD' => array(
+        ],
+        'HKD' => [
             'name' => 'Hong Kong Dollar',
             'numericCode' => 344,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'HNL' => array(
+        ],
+        'HNL' => [
             'name' => 'Lempira',
             'numericCode' => 340,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'HRK' => array(
+        ],
+        'HRK' => [
             'name' => 'Croatian Kuna',
             'numericCode' => 191,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'HTG' => array(
+        ],
+        'HTG' => [
             'name' => 'Gourde',
             'numericCode' => 332,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'HUF' => array(
+        ],
+        'HUF' => [
             'name' => 'Forint',
             'numericCode' => 348,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'IDR' => array(
+        ],
+        'IDR' => [
             'name' => 'Rupiah',
             'numericCode' => 360,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ILS' => array(
+        ],
+        'ILS' => [
             'name' => 'New Israeli Sheqel',
             'numericCode' => 376,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'INR' => array(
+        ],
+        'INR' => [
             'name' => 'Indian Rupee',
             'numericCode' => 356,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'IQD' => array(
+        ],
+        'IQD' => [
             'name' => 'Iraqi Dinar',
             'numericCode' => 368,
             'fractionDecimals' => 3,
             'fractionUnit' => 1000,
-        ),
-        'IRR' => array(
+        ],
+        'IRR' => [
             'name' => 'Iranian Rial',
             'numericCode' => 364,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ISK' => array(
+        ],
+        'ISK' => [
             'name' => 'Iceland Krona',
             'numericCode' => 352,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'JMD' => array(
+        ],
+        'JMD' => [
             'name' => 'Jamaican Dollar',
             'numericCode' => 388,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'JOD' => array(
+        ],
+        'JOD' => [
             'name' => 'Jordanian Dinar',
             'numericCode' => 400,
             'fractionDecimals' => 3,
             'fractionUnit' => 100,
-        ),
-        'JPY' => array(
+        ],
+        'JPY' => [
             'name' => 'Yen',
             'numericCode' => 392,
             'fractionDecimals' => 0,
             'fractionUnit' => 1,
-        ),
-        'KES' => array(
+        ],
+        'KES' => [
             'name' => 'Kenyan Shilling',
             'numericCode' => 404,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'KGS' => array(
+        ],
+        'KGS' => [
             'name' => 'Som',
             'numericCode' => 417,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'KHR' => array(
+        ],
+        'KHR' => [
             'name' => 'Riel',
             'numericCode' => 116,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'KMF' => array(
+        ],
+        'KMF' => [
             'name' => 'Comoro Franc',
             'numericCode' => 174,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'KPW' => array(
+        ],
+        'KPW' => [
             'name' => 'North Korean Won',
             'numericCode' => 408,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'KRW' => array(
+        ],
+        'KRW' => [
             'name' => 'Won',
             'numericCode' => 410,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'KWD' => array(
+        ],
+        'KWD' => [
             'name' => 'Kuwaiti Dinar',
             'numericCode' => 414,
             'fractionDecimals' => 3,
             'fractionUnit' => 1000,
-        ),
-        'KYD' => array(
+        ],
+        'KYD' => [
             'name' => 'Cayman Islands Dollar',
             'numericCode' => 136,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'KZT' => array(
+        ],
+        'KZT' => [
             'name' => 'Tenge',
             'numericCode' => 398,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'LAK' => array(
+        ],
+        'LAK' => [
             'name' => 'Kip',
             'numericCode' => 418,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'LBP' => array(
+        ],
+        'LBP' => [
             'name' => 'Lebanese Pound',
             'numericCode' => 422,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'LKR' => array(
+        ],
+        'LKR' => [
             'name' => 'Sri Lanka Rupee',
             'numericCode' => 144,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'LRD' => array(
+        ],
+        'LRD' => [
             'name' => 'Liberian Dollar',
             'numericCode' => 430,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'LSL' => array(
+        ],
+        'LSL' => [
             'name' => 'Loti',
             'numericCode' => 426,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'LYD' => array(
+        ],
+        'LYD' => [
             'name' => 'Libyan Dinar',
             'numericCode' => 434,
             'fractionDecimals' => 3,
             'fractionUnit' => 1000,
-        ),
-        'MAD' => array(
+        ],
+        'MAD' => [
             'name' => 'Moroccan Dirham',
             'numericCode' => 504,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MDL' => array(
+        ],
+        'MDL' => [
             'name' => 'Moldovan Leu',
             'numericCode' => 498,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MGA' => array(
+        ],
+        'MGA' => [
             'name' => 'Malagasy Ariary',
             'numericCode' => 969,
             'fractionDecimals' => 2,
             'fractionUnit' => 5,
-        ),
-        'MKD' => array(
+        ],
+        'MKD' => [
             'name' => 'Denar',
             'numericCode' => 807,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MMK' => array(
+        ],
+        'MMK' => [
             'name' => 'Kyat',
             'numericCode' => 104,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MNT' => array(
+        ],
+        'MNT' => [
             'name' => 'Tugrik',
             'numericCode' => 496,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MOP' => array(
+        ],
+        'MOP' => [
             'name' => 'Pataca',
             'numericCode' => 446,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MRO' => array(
+        ],
+        'MRO' => [
             'name' => 'Ouguiya',
             'numericCode' => 478,
             'fractionDecimals' => 2,
             'fractionUnit' => 5,
-        ),
-        'MUR' => array(
+        ],
+        'MUR' => [
             'name' => 'Mauritius Rupee',
             'numericCode' => 480,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MVR' => array(
+        ],
+        'MVR' => [
             'name' => 'Rufiyaa',
             'numericCode' => 462,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MWK' => array(
+        ],
+        'MWK' => [
             'name' => 'Kwacha',
             'numericCode' => 454,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MXN' => array(
+        ],
+        'MXN' => [
             'name' => 'Mexican Peso',
             'numericCode' => 484,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MXV' => array(
+        ],
+        'MXV' => [
             'name' => 'Mexican Unidad de Inversion (UDI)',
             'numericCode' => 979,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MYR' => array(
+        ],
+        'MYR' => [
             'name' => 'Malaysian Ringgit',
             'numericCode' => 458,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'MZN' => array(
+        ],
+        'MZN' => [
             'name' => 'Mozambique Metical',
             'numericCode' => 943,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'NAD' => array(
+        ],
+        'NAD' => [
             'name' => 'Namibia Dollar',
             'numericCode' => 516,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'NGN' => array(
+        ],
+        'NGN' => [
             'name' => 'Naira',
             'numericCode' => 566,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'NIO' => array(
+        ],
+        'NIO' => [
             'name' => 'Cordoba Oro',
             'numericCode' => 558,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'NOK' => array(
+        ],
+        'NOK' => [
             'name' => 'Norwegian Krone',
             'numericCode' => 578,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'NPR' => array(
+        ],
+        'NPR' => [
             'name' => 'Nepalese Rupee',
             'numericCode' => 524,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'NZD' => array(
+        ],
+        'NZD' => [
             'name' => 'New Zealand Dollar',
             'numericCode' => 554,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'OMR' => array(
+        ],
+        'OMR' => [
             'name' => 'Rial Omani',
             'numericCode' => 512,
             'fractionDecimals' => 3,
             'fractionUnit' => 1000,
-        ),
-        'PAB' => array(
+        ],
+        'PAB' => [
             'name' => 'Balboa',
             'numericCode' => 590,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'PEN' => array(
+        ],
+        'PEN' => [
             'name' => 'Nuevo Sol',
             'numericCode' => 604,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'PGK' => array(
+        ],
+        'PGK' => [
             'name' => 'Kina',
             'numericCode' => 598,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'PHP' => array(
+        ],
+        'PHP' => [
             'name' => 'Philippine Peso',
             'numericCode' => 608,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'PKR' => array(
+        ],
+        'PKR' => [
             'name' => 'Pakistan Rupee',
             'numericCode' => 586,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'PLN' => array(
+        ],
+        'PLN' => [
             'name' => 'Zloty',
             'numericCode' => 985,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'PYG' => array(
+        ],
+        'PYG' => [
             'name' => 'Guarani',
             'numericCode' => 600,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'QAR' => array(
+        ],
+        'QAR' => [
             'name' => 'Qatari Rial',
             'numericCode' => 634,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'RON' => array(
+        ],
+        'RON' => [
             'name' => 'New Romanian Leu',
             'numericCode' => 946,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'RSD' => array(
+        ],
+        'RSD' => [
             'name' => 'Serbian Dinar',
             'numericCode' => 941,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'RUB' => array(
+        ],
+        'RUB' => [
             'name' => 'Russian Ruble',
             'numericCode' => 643,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'RWF' => array(
+        ],
+        'RWF' => [
             'name' => 'Rwanda Franc',
             'numericCode' => 646,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'SAR' => array(
+        ],
+        'SAR' => [
             'name' => 'Saudi Riyal',
             'numericCode' => 682,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SBD' => array(
+        ],
+        'SBD' => [
             'name' => 'Solomon Islands Dollar',
             'numericCode' => 90,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SCR' => array(
+        ],
+        'SCR' => [
             'name' => 'Seychelles Rupee',
             'numericCode' => 690,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SDG' => array(
+        ],
+        'SDG' => [
             'name' => 'Sudanese Pound',
             'numericCode' => 938,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SEK' => array(
+        ],
+        'SEK' => [
             'name' => 'Swedish Krona',
             'numericCode' => 752,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SGD' => array(
+        ],
+        'SGD' => [
             'name' => 'Singapore Dollar',
             'numericCode' => 702,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SHP' => array(
+        ],
+        'SHP' => [
             'name' => 'Saint Helena Pound',
             'numericCode' => 654,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SLL' => array(
+        ],
+        'SLL' => [
             'name' => 'Leone',
             'numericCode' => 694,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SOS' => array(
+        ],
+        'SOS' => [
             'name' => 'Somali Shilling',
             'numericCode' => 706,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SRD' => array(
+        ],
+        'SRD' => [
             'name' => 'Surinam Dollar',
             'numericCode' => 968,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SSP' => array(
+        ],
+        'SSP' => [
             'name' => 'South Sudanese Pound',
             'numericCode' => 728,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'STD' => array(
+        ],
+        'STD' => [
             'name' => 'Dobra',
             'numericCode' => 678,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SYP' => array(
+        ],
+        'SYP' => [
             'name' => 'Syrian Pound',
             'numericCode' => 760,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'SZL' => array(
+        ],
+        'SZL' => [
             'name' => 'Lilangeni',
             'numericCode' => 748,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'THB' => array(
+        ],
+        'THB' => [
             'name' => 'Baht',
             'numericCode' => 764,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'TJS' => array(
+        ],
+        'TJS' => [
             'name' => 'Somoni',
             'numericCode' => 972,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'TMT' => array(
+        ],
+        'TMT' => [
             'name' => 'Turkmenistan New Manat',
             'numericCode' => 934,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'TND' => array(
+        ],
+        'TND' => [
             'name' => 'Tunisian Dinar',
             'numericCode' => 788,
             'fractionDecimals' => 3,
             'fractionUnit' => 1000,
-        ),
-        'TOP' => array(
+        ],
+        'TOP' => [
             'name' => 'Pa’anga',
             'numericCode' => 776,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'TRY' => array(
+        ],
+        'TRY' => [
             'name' => 'Turkish Lira',
             'numericCode' => 949,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'TTD' => array(
+        ],
+        'TTD' => [
             'name' => 'Trinidad and Tobago Dollar',
             'numericCode' => 780,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'TWD' => array(
+        ],
+        'TWD' => [
             'name' => 'New Taiwan Dollar',
             'numericCode' => 901,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'TZS' => array(
+        ],
+        'TZS' => [
             'name' => 'Tanzanian Shilling',
             'numericCode' => 834,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'UAH' => array(
+        ],
+        'UAH' => [
             'name' => 'Hryvnia',
             'numericCode' => 980,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'UGX' => array(
+        ],
+        'UGX' => [
             'name' => 'Uganda Shilling',
             'numericCode' => 800,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'USD' => array(
+        ],
+        'USD' => [
             'name' => 'US Dollar',
             'numericCode' => 840,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'USN' => array(
+        ],
+        'USN' => [
             'name' => 'US Dollar (Next day)',
             'numericCode' => 997,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'USS' => array(
+        ],
+        'USS' => [
             'name' => 'US Dollar (Same day)',
             'numericCode' => 998,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'UYI' => array(
+        ],
+        'UYI' => [
             'name' => 'Uruguay Peso en Unidades Indexadas (URUIURUI)',
             'numericCode' => 940,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'UYU' => array(
+        ],
+        'UYU' => [
             'name' => 'Peso Uruguayo',
             'numericCode' => 858,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'UZS' => array(
+        ],
+        'UZS' => [
             'name' => 'Uzbekistan Sum',
             'numericCode' => 860,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'VEF' => array(
+        ],
+        'VEF' => [
             'name' => 'Bolivar',
             'numericCode' => 937,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'VND' => array(
+        ],
+        'VND' => [
             'name' => 'Dong',
             'numericCode' => 704,
             'fractionDecimals' => 0,
             'fractionUnit' => 10,
-        ),
-        'VUV' => array(
+        ],
+        'VUV' => [
             'name' => 'Vatu',
             'numericCode' => 548,
             'fractionDecimals' => 0,
             'fractionUnit' => 1,
-        ),
-        'WST' => array(
+        ],
+        'WST' => [
             'name' => 'Tala',
             'numericCode' => 882,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'XAF' => array(
+        ],
+        'XAF' => [
             'name' => 'CFA Franc BEAC',
             'numericCode' => 950,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XAG' => array(
+        ],
+        'XAG' => [
             'name' => 'Silver',
             'numericCode' => 961,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XAU' => array(
+        ],
+        'XAU' => [
             'name' => 'Gold',
             'numericCode' => 959,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XBA' => array(
+        ],
+        'XBA' => [
             'name' => 'Bond Markets Unit European Composite Unit (EURCO)',
             'numericCode' => 955,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XBB' => array(
+        ],
+        'XBB' => [
             'name' => 'Bond Markets Unit European Monetary Unit (E.M.U.-6)',
             'numericCode' => 956,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XBC' => array(
+        ],
+        'XBC' => [
             'name' => 'Bond Markets Unit European Unit of Account 9 (E.U.A.-9)',
             'numericCode' => 957,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XBD' => array(
+        ],
+        'XBD' => [
             'name' => 'Bond Markets Unit European Unit of Account 17 (E.U.A.-17)',
             'numericCode' => 958,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XCD' => array(
+        ],
+        'XCD' => [
             'name' => 'East Caribbean Dollar',
             'numericCode' => 951,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'XDR' => array(
+        ],
+        'XDR' => [
             'name' => 'SDR (Special Drawing Right)',
             'numericCode' => 960,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XFU' => array(
+        ],
+        'XFU' => [
             'name' => 'UIC-Franc',
             'numericCode' => 958,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XOF' => array(
+        ],
+        'XOF' => [
             'name' => 'CFA Franc BCEAO',
             'numericCode' => 952,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XPD' => array(
+        ],
+        'XPD' => [
             'name' => 'Palladium',
             'numericCode' => 964,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XPF' => array(
+        ],
+        'XPF' => [
             'name' => 'CFP Franc',
             'numericCode' => 953,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XPT' => array(
+        ],
+        'XPT' => [
             'name' => 'Platinum',
             'numericCode' => 962,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XSU' => array(
+        ],
+        'XSU' => [
             'name' => 'Sucre',
             'numericCode' => 994,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XTS' => array(
+        ],
+        'XTS' => [
             'name' => 'Codes specifically reserved for testing purposes',
             'numericCode' => 963,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XUA' => array(
+        ],
+        'XUA' => [
             'name' => 'ADB Unit of Account',
             'numericCode' => 965,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'XXX' => array(
+        ],
+        'XXX' => [
             'name' => 'The codes assigned for transactions where no currency is involved',
             'numericCode' => 999,
             'fractionDecimals' => 0,
             'fractionUnit' => 100,
-        ),
-        'YER' => array(
+        ],
+        'YER' => [
             'name' => 'Yemeni Rial',
             'numericCode' => 886,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ZAR' => array(
+        ],
+        'ZAR' => [
             'name' => 'Rand',
             'numericCode' => 710,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        ),
-        'ZMW' => array(
+        ],
+        'ZMW' => [
             'name' => 'Zambian Kwacha',
             'numericCode' => 967,
             'fractionDecimals' => 2,
             'fractionUnit' => 100,
-        )
-    );
+        ]
+    ];
 
     /**
      * Private Constructor to disallow instantiation.

--- a/src/Helper/HtmlMarkupSerializationHelper.php
+++ b/src/Helper/HtmlMarkupSerializationHelper.php
@@ -217,7 +217,7 @@ class HtmlMarkupSerializationHelper extends AbstractHelper
             }
             return $encodedCollection;
         } elseif (is_array($val)) {
-            $encodedArray = array();
+            $encodedArray = [];
             foreach ($val as $key => $item) {
                 $encodedArray[$key] = self::encodeHtmlEntities($item);
             }

--- a/src/Helper/IframeHelper.php
+++ b/src/Helper/IframeHelper.php
@@ -66,7 +66,7 @@ final class IframeHelper extends AbstractHelper
         IframeInterface $iframe,
         AccountInterface $account = null,
         UserInterface $user = null,
-        array $params = array()
+        array $params = []
     ) {
         $defaultParameters = self::getDefaultParams($iframe);
         if ($account instanceof AccountInterface) {
@@ -93,17 +93,17 @@ final class IframeHelper extends AbstractHelper
                 // reason is invalid, which is the case when switching between environments.
                 $url = HttpRequest::buildUri(
                     Nosto::getBaseUrl() . self::IFRAME_URI_UNINSTALL . '?' . $queryParams,
-                    array(
+                    [
                         '{platform}' => $iframe->getPlatform(),
-                    )
+                    ]
                 );
             }
         } else {
             $url = HttpRequest::buildUri(
                 Nosto::getBaseUrl() . self::IFRAME_URI_INSTALL . '?' . $queryParams,
-                array(
+                [
                     '{platform}' => $iframe->getPlatform(),
-                )
+                ]
             );
         }
 
@@ -116,7 +116,7 @@ final class IframeHelper extends AbstractHelper
      */
     public static function getDefaultParams(IframeInterface $iframe)
     {
-        return array(
+        return [
             'lang' => strtolower($iframe->getLanguageIsoCode()),
             'ps_version' => $iframe->getVersionPlatform(),
             'nt_version' => $iframe->getVersionModule(),
@@ -132,6 +132,6 @@ final class IframeHelper extends AbstractHelper
             'lname' => $iframe->getLastName(),
             'email' => $iframe->getEmail(),
             'modules' => $iframe->getModules()
-        );
+        ];
     }
 }

--- a/src/Helper/OAuthHelper.php
+++ b/src/Helper/OAuthHelper.php
@@ -60,12 +60,12 @@ class OAuthHelper extends AbstractHelper
 
         return HttpRequest::buildUri(
             $oauthBaseUrl . self::PATH_AUTH,
-            array(
+            [
                 '{cid}' => $params->getClientId(),
                 '{uri}' => $params->getRedirectUrl(),
                 '{sco}' => implode(' ', $params->getScopes()),
                 '{iso}' => strtolower($params->getLanguageIsoCode()),
-            )
+            ]
         );
     }
 }

--- a/src/Helper/SerializationHelper.php
+++ b/src/Helper/SerializationHelper.php
@@ -52,7 +52,7 @@ class SerializationHelper extends AbstractHelper
 
     public static function serialize($object)
     {
-        $items = array();
+        $items = [];
         if ($object instanceof Traversable || is_array($object)) {
             foreach ($object as $item) {
                 if (is_object($item)) {
@@ -80,7 +80,7 @@ class SerializationHelper extends AbstractHelper
      */
     private static function toArray($object, $keyCaseType = self::SNAKE_CASE)
     {
-        $json = array();
+        $json = [];
         $props = Reflection::getObjectProperties($object);
         foreach ($props as $key => $value) {
             $check_references = explode("_", $key);
@@ -111,7 +111,7 @@ class SerializationHelper extends AbstractHelper
                 $json[$key] = self::toArray($value);
             } else {
                 if (is_array($value)) {
-                    $json[$key] = array();
+                    $json[$key] = [];
                     if (ArrayHelper::isAssoc($value)) {
                         foreach ($value as $k => $anObject) {
                             if (is_object($anObject)) {

--- a/src/Helper/ValidationHelper.php
+++ b/src/Helper/ValidationHelper.php
@@ -52,7 +52,7 @@ class ValidationHelper extends AbstractHelper
     /**
      * @var array map of validation errors per attribute
      */
-    private $errors = array();
+    private $errors = [];
 
     /**
      * Constructor.
@@ -84,8 +84,8 @@ class ValidationHelper extends AbstractHelper
                         $validator
                     ));
                 }
-                $params = array_merge(array($properties), array_slice($rule, 2));
-                $isValid = call_user_func_array(array($this, $validator), $params);
+                $params = array_merge([$properties], array_slice($rule, 2));
+                $isValid = call_user_func_array([$this, $validator], $params);
                 if (!$isValid) {
                     $valid = false;
                 }
@@ -144,7 +144,7 @@ class ValidationHelper extends AbstractHelper
     protected function addError($attribute, $message)
     {
         if (!isset($this->errors[$attribute])) {
-            $this->errors[$attribute] = array();
+            $this->errors[$attribute] = [];
         }
         $this->errors[$attribute][] = $message;
     }

--- a/src/Mixins/HtmlEncoderTrait.php
+++ b/src/Mixins/HtmlEncoderTrait.php
@@ -48,7 +48,7 @@ trait HtmlEncoderTrait
     /**
      * @var array
      */
-    private $varsToEncode = array();
+    private $varsToEncode = [];
 
     /**
      * @var bool
@@ -62,7 +62,7 @@ trait HtmlEncoderTrait
     public function varsToEncode()
     {
         if ($this->isAutoEncodeAll() === true) {
-            $allClassVariables = array();
+            $allClassVariables = [];
             $vars = Reflection::getObjectProperties($this);
             foreach ($vars as $classVar => $val) {
                 if (HtmlMarkupSerializationHelper::encodableClassVariable($this, $classVar)) {

--- a/src/Mixins/IframeTrait.php
+++ b/src/Mixins/IframeTrait.php
@@ -57,7 +57,7 @@ trait IframeTrait
      * @param array $params additional parameters to add to the iframe url.
      * @return string the iframe url.
      */
-    public function buildURL(array $params = array())
+    public function buildURL(array $params = [])
     {
         $iframe = self::getIframe();
         $defaultParameters = IframeHelper::getDefaultParams($iframe);
@@ -81,21 +81,21 @@ trait IframeTrait
                 // allow to remove Nosto and start over.
                 // The only case when this should happen is when the api token for some
                 // reason is invalid, which is the case when switching between environments.
-                $errorParams = array(
+                $errorParams = [
                     Nosto::URL_PARAM_MESSAGE_TYPE => Nosto::TYPE_ERROR,
                     Nosto::URL_PARAM_MESSAGE_CODE => Nosto::CODE_ACCOUNT_DELETE,
                     Nosto::URL_PARAM_MESSAGE_TEXT => $e->getMessage()
-                );
+                ];
                 $queryParams = http_build_query(array_merge($defaultParameters, $params, $errorParams));
                 $url = HttpRequest::buildUri(
                     Nosto::getBaseUrl() . '/hub/{platform}/uninstall' . '?' . $queryParams,
-                    array('{platform}' => $iframe->getPlatform(),)
+                    ['{platform}' => $iframe->getPlatform(),]
                 );
             }
         } else {
             $url = HttpRequest::buildUri(
                 Nosto::getBaseUrl() . '/hub/{platform}/install' . '?' . $queryParams,
-                array('{platform}' => $iframe->getPlatform())
+                ['{platform}' => $iframe->getPlatform()]
             );
         }
 

--- a/src/Mixins/OauthTrait.php
+++ b/src/Mixins/OauthTrait.php
@@ -60,10 +60,10 @@ trait OauthTrait
 
                 if (self::save($account)) {
                     self::redirect(
-                        array(
+                        [
                             Nosto::URL_PARAM_MESSAGE_TYPE => Nosto::TYPE_SUCCESS,
                             Nosto::URL_PARAM_MESSAGE_CODE => Nosto::CODE_ACCOUNT_CONNECT
-                        )
+                        ]
                     );
                     return;
                 } else {
@@ -72,11 +72,11 @@ trait OauthTrait
             } catch (NostoException $e) {
                 self::logError($e);
                 self::redirect(
-                    array(
+                    [
                         Nosto::URL_PARAM_MESSAGE_TYPE => Nosto::TYPE_ERROR,
                         Nosto::URL_PARAM_MESSAGE_CODE => Nosto::CODE_ACCOUNT_CONNECT,
                         Nosto::URL_PARAM_MESSAGE_TEXT => $e->getMessage()
-                    )
+                    ]
                 );
                 return;
             }
@@ -90,11 +90,11 @@ trait OauthTrait
             }
             self::logError(new Exception($logMsg));
             self::redirect(
-                array(
+                [
                     Nosto::URL_PARAM_MESSAGE_TYPE => Nosto::TYPE_ERROR,
                     Nosto::URL_PARAM_MESSAGE_CODE => Nosto::CODE_ACCOUNT_CONNECT,
                     Nosto::URL_PARAM_MESSAGE_TEXT => $desc
-                )
+                ]
             );
         } else {
             self::notFound();

--- a/src/Model/AbstractCollection.php
+++ b/src/Model/AbstractCollection.php
@@ -48,7 +48,7 @@ use Nosto\Helper\SerializationHelper;
 abstract class AbstractCollection implements Iterator, Countable
 {
 
-    protected $var = array();
+    protected $var = [];
 
     /**
      * @see Iterator::rewind()
@@ -115,6 +115,6 @@ abstract class AbstractCollection implements Iterator, Countable
      */
     public function clear()
     {
-        $this->var = array();
+        $this->var = [];
     }
 }

--- a/src/Model/Cart/Cart.php
+++ b/src/Model/Cart/Cart.php
@@ -58,7 +58,7 @@ class Cart extends AbstractObject implements MarkupableInterface
     /**
      * @var LineItemInterface[] the array of items in the shopping cart
      */
-    private $items = array();
+    private $items = [];
 
     /**
      * Returns the items in the shopping cart
@@ -77,7 +77,7 @@ class Cart extends AbstractObject implements MarkupableInterface
      */
     public function setItems(array $items)
     {
-        $this->items = array();
+        $this->items = [];
         foreach ($items as $item) {
             $this->addItem($item);
         }

--- a/src/Model/ExchangeRateCollection.php
+++ b/src/Model/ExchangeRateCollection.php
@@ -47,7 +47,7 @@ class ExchangeRateCollection extends AbstractObject
     /**
      * @var array the array if exchange rates keyed by the rate code
      */
-    private $rates = array();
+    private $rates = [];
 
     /**
      * Adds an exchange rate to the array of rates

--- a/src/Model/Iframe.php
+++ b/src/Model/Iframe.php
@@ -108,7 +108,7 @@ class Iframe extends AbstractObject implements IframeInterface
     /**
      * @var array the associative array with installed modules
      */
-    private $modules = array();
+    private $modules = [];
 
     public function __construct()
     {

--- a/src/Model/Order/Order.php
+++ b/src/Model/Order/Order.php
@@ -87,7 +87,7 @@ class Order extends AbstractObject implements
     /**
      * @var LineItemInterface[] the list of items in the OrderConfirm
      */
-    private $purchasedItems = array();
+    private $purchasedItems = [];
 
     /**
      * @var string the latest OrderConfirm status of the OrderConfirm
@@ -119,7 +119,7 @@ class Order extends AbstractObject implements
      */
     public function validationRules()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -308,13 +308,13 @@ class Order extends AbstractObject implements
      */
     public function getOrderStatuses()
     {
-        $formatted = array();
+        $formatted = [];
         if ($this->orderStatuses instanceof Traversable
             || is_array($this->orderStatuses)
         ) {
             foreach ($this->orderStatuses as $orderStatus) {
                 if (!isset($formatted[$orderStatus->getCode()])) {
-                    $formatted[$orderStatus->getCode()] = array();
+                    $formatted[$orderStatus->getCode()] = [];
                 }
                 $formatted[$orderStatus->getCode()][] = $orderStatus->getDate();
             }

--- a/src/Model/Product/Product.php
+++ b/src/Model/Product/Product.php
@@ -242,7 +242,7 @@ class Product extends AbstractObject implements
      * An array of custom attributes
      * @var array
      */
-    private $customFields = array();
+    private $customFields = [];
 
     /**
      * Product publication date in shop
@@ -266,9 +266,9 @@ class Product extends AbstractObject implements
      */
     public function validationRules()
     {
-        return array(
-            array(array('productId'), 'required')
-        );
+        return [
+            [['productId'], 'required']
+        ];
     }
 
     /**
@@ -989,7 +989,7 @@ class Product extends AbstractObject implements
     public function addCustomField($attribute, $value)
     {
         if ($this->customFields === null) {
-            $this->customFields = array();
+            $this->customFields = [];
         }
         $this->customFields[$attribute] = $value;
     }

--- a/src/Model/Product/Sku.php
+++ b/src/Model/Product/Sku.php
@@ -113,7 +113,7 @@ class Sku extends AbstractObject implements
      * An array of custom attributes
      * @var array
      */
-    private $customFields = array();
+    private $customFields = [];
 
     /**
      * @var int|null product stock level
@@ -291,7 +291,7 @@ class Sku extends AbstractObject implements
     public function addCustomField($attribute, $value)
     {
         if ($this->customFields === null) {
-            $this->customFields = array();
+            $this->customFields = [];
         }
         $this->customFields[$attribute] = $value;
     }

--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -70,7 +70,7 @@ class Settings extends AbstractObject implements SettingsInterface
     /**
      * @var array list of currency codes and the currency formats objects supported by the store .
      */
-    private $currencies = array();
+    private $currencies = [];
 
     /**
      * @var string default variation id

--- a/src/Model/Signup/Account.php
+++ b/src/Model/Signup/Account.php
@@ -56,7 +56,7 @@ class Account extends AbstractObject implements AccountInterface, ValidatableInt
     /**
      * @var Token[] the Nosto API tokens associated with this account.
      */
-    private $tokens = array();
+    private $tokens = [];
 
     /**
      * Constructor.
@@ -120,9 +120,9 @@ class Account extends AbstractObject implements AccountInterface, ValidatableInt
      */
     public function validationRules()
     {
-        return array(
-            array(array('name'), 'required')
-        );
+        return [
+            [['name'], 'required']
+        ];
     }
 
     /**
@@ -193,7 +193,7 @@ class Account extends AbstractObject implements AccountInterface, ValidatableInt
     public function getMissingTokens()
     {
         $allTokens = Token::getApiTokenNames();
-        $missingTokens = array();
+        $missingTokens = [];
         foreach ($allTokens as $token) {
             if (!$this->getApiToken($token)) {
                 $missingTokens[] = $token;

--- a/src/Model/StringCollection.php
+++ b/src/Model/StringCollection.php
@@ -106,7 +106,7 @@ class StringCollection extends AbstractCollection implements MarkupableCollectio
     public function setData($data)
     {
         if ($data === null) {
-            $this->var = array();
+            $this->var = [];
         } else {
             $this->var = $data;
         }

--- a/src/OAuth.php
+++ b/src/OAuth.php
@@ -48,7 +48,7 @@ class OAuth implements OAuthInterface
     /**
      * @var array The scopes for the OAuth2 request.
      */
-    private $scopes = array();
+    private $scopes = [];
 
     /**
      * @var string the url where the oauth2 server should redirect after

--- a/src/Operation/AccountSignup.php
+++ b/src/Operation/AccountSignup.php
@@ -75,7 +75,7 @@ class AccountSignup extends AbstractRESTOperation
     public function create()
     {
         $request = $this->initRequest($this->account->getSignUpApiToken());
-        $request->setReplaceParams(array('{lang}' => $this->account->getLanguageCode()));
+        $request->setReplaceParams(['{lang}' => $this->account->getLanguageCode()]);
         $response = $request->post($this->account);
         $results = $request->getResultHandler()->parse($response);
 

--- a/src/Operation/CartOperation.php
+++ b/src/Operation/CartOperation.php
@@ -64,11 +64,11 @@ class CartOperation extends AbstractAuthenticatedOperation
             false
         );
         $channelName = 'cartUpdated/' . $accountId . '/' . $nostoCustomerId;
-        $data = array();
-        $item = array();
+        $data = [];
+        $item = [];
         $item['channel'] = $channelName;
-        $item['formats'] = array('json-object' => json_decode(SerializationHelper::serialize($update)));
-        $data['items'] = array($item);
+        $item['formats'] = ['json-object' => json_decode(SerializationHelper::serialize($update))];
+        $data['items'] = [$item];
         $updateJson = json_encode($data);
         $response = $request->postRaw($updateJson);
 

--- a/src/Operation/InitiateSso.php
+++ b/src/Operation/InitiateSso.php
@@ -66,7 +66,7 @@ class InitiateSso extends AbstractAuthenticatedOperation
             $this->account->getApiToken(Token::API_SSO),
             $this->account->getName()
         );
-        $request->setReplaceParams(array('{platform}' => $platform));
+        $request->setReplaceParams(['{platform}' => $platform]);
         $response = $request->post($user);
 
         return $request->getResultHandler()->parse($response);

--- a/src/Operation/MarketingPermission.php
+++ b/src/Operation/MarketingPermission.php
@@ -73,7 +73,7 @@ class MarketingPermission extends AbstractAuthenticatedOperation
             $this->activeDomain
         );
 
-        $replaceParams = array('{email}' => $email, '{state}' => $hasPermission ? 'true' : 'false');
+        $replaceParams = ['{email}' => $email, '{state}' => $hasPermission ? 'true' : 'false'];
         $request->setReplaceParams($replaceParams);
         $response = $request->postRaw('');
 

--- a/src/Operation/OAuth/AuthorizationCode.php
+++ b/src/Operation/OAuth/AuthorizationCode.php
@@ -76,7 +76,7 @@ class AuthorizationCode extends AbstractOperation
     /**
      * @var array list of scopes to request access for during "PATH_AUTH" request.
      */
-    private $scopes = array();
+    private $scopes = [];
 
     /**
      * @param OAuthInterface $metaData
@@ -106,12 +106,12 @@ class AuthorizationCode extends AbstractOperation
         $request = $this->initRequest(null, null, null, false);
         $request->setUrl(Nosto::getOAuthBaseUrl() . self::PATH_TOKEN);
         $request->setReplaceParams(
-            array(
+            [
                 '{cid}' => $this->clientId,
                 '{sec}' => $this->clientSecret,
                 '{uri}' => $this->redirectUrl,
                 '{cod}' => $code
-            )
+            ]
         );
         $response = $request->get();
         $result = $request->getResultHandler()->parse($response);

--- a/src/Operation/OAuth/ExchangeTokens.php
+++ b/src/Operation/OAuth/ExchangeTokens.php
@@ -77,7 +77,7 @@ class ExchangeTokens extends AbstractOperation
     public function exchange(NostoOAuthToken $token)
     {
         $request = $this->initRequest(null, null, null, false);
-        $request->setQueryParams(array('access_token' => $token->getAccessToken()));
+        $request->setQueryParams(['access_token' => $token->getAccessToken()]);
         $response = $request->get();
         $results = $request->getResultHandler()->parse($response);
 

--- a/src/Request/Api/Token.php
+++ b/src/Request/Api/Token.php
@@ -57,14 +57,14 @@ class Token extends AbstractObject implements ValidatableInterface
     /**
      * @var array list of valid api tokens to request from Nosto.
      */
-    public static $tokenNames = array(
+    public static $tokenNames = [
         self::API_SSO,
         self::API_PRODUCTS,
         self::API_EXCHANGE_RATES,
         self::API_SETTINGS,
         self::API_EMAIL,
         self::API_GRAPHQL
-    );
+    ];
     /**
      * @var string the token name, must be one of the defined tokens from self::$tokenNames.
      */
@@ -115,7 +115,7 @@ class Token extends AbstractObject implements ValidatableInterface
      */
     public static function parseTokens(array $tokens, $prefix = '', $postfix = '')
     {
-        $parsedTokens = array();
+        $parsedTokens = [];
         foreach (self::$tokenNames as $name) {
             $key = $prefix . $name . $postfix;
             if (isset($tokens[$key])) {
@@ -142,10 +142,10 @@ class Token extends AbstractObject implements ValidatableInterface
      */
     public static function getMandatoryApiTokenNames()
     {
-        return array(
+        return [
             self::API_SSO,
             self::API_PRODUCTS
-        );
+        ];
     }
 
     /**
@@ -153,10 +153,10 @@ class Token extends AbstractObject implements ValidatableInterface
      */
     public function validationRules()
     {
-        return array(
-            array(array('name', 'value'), 'required'),
-            array(array('name'), 'in', array_merge(self::$tokenNames, array(self::API_CREATE)))
-        );
+        return [
+            [['name', 'value'], 'required'],
+            [['name'], 'in', array_merge(self::$tokenNames, [self::API_CREATE])]
+        ];
     }
 
     /**

--- a/src/Request/Http/Adapter/Adapter.php
+++ b/src/Request/Http/Adapter/Adapter.php
@@ -58,7 +58,7 @@ abstract class Adapter
     /**
      * @var array the request headers.
      */
-    protected $headers = array();
+    protected $headers = [];
 
     /**
      * @var mixed the request content.
@@ -88,7 +88,7 @@ abstract class Adapter
      * @param array $options the request options.
      * @return HttpResponse the response object.
      */
-    abstract public function get($url, array $options = array());
+    abstract public function get($url, array $options = []);
 
     /**
      * Does a POST request and returns the http response object.
@@ -97,7 +97,7 @@ abstract class Adapter
      * @param array $options the request options.
      * @return HttpResponse the response object.
      */
-    abstract public function post($url, array $options = array());
+    abstract public function post($url, array $options = []);
 
     /**
      * Does a PUT request and returns the http response object.
@@ -106,7 +106,7 @@ abstract class Adapter
      * @param array $options the request options.
      * @return HttpResponse the response object.
      */
-    abstract public function put($url, array $options = array());
+    abstract public function put($url, array $options = []);
 
     /**
      * Does a DELETE request and returns the http response object.
@@ -115,14 +115,14 @@ abstract class Adapter
      * @param array $options the request options.
      * @return HttpResponse the response object.
      */
-    abstract public function delete($url, array $options = array());
+    abstract public function delete($url, array $options = []);
 
     /**
      * Initializes the request options.
      *
      * @param array $options the options.
      */
-    protected function init(array $options = array())
+    protected function init(array $options = [])
     {
         foreach ($options as $key => $value) {
             if (property_exists($this, $key)) {

--- a/src/Request/Http/Adapter/Curl.php
+++ b/src/Request/Http/Adapter/Curl.php
@@ -64,17 +64,17 @@ class Curl extends Adapter
     /**
      * @inheritdoc
      */
-    public function get($url, array $options = array())
+    public function get($url, array $options = [])
     {
         $this->init($options);
         return $this->send(
-            array(
+            [
                 CURLOPT_URL => $url,
                 CURLOPT_HEADER => 1,
                 CURLOPT_FRESH_CONNECT => 1,
                 CURLOPT_RETURNTRANSFER => 1,
                 CURLOPT_FORBID_REUSE => 1,
-            )
+            ]
         );
     }
 
@@ -99,7 +99,7 @@ class Curl extends Adapter
             $curlOptions[CURLOPT_CONNECTTIMEOUT] = $this->getConnectTimeout();
         }
         if (empty($curlOptions[CURLOPT_HTTPHEADER]) || !is_array($curlOptions[CURLOPT_HTTPHEADER])) {
-            $curlOptions[CURLOPT_HTTPHEADER] = array();
+            $curlOptions[CURLOPT_HTTPHEADER] = [];
         }
         $curlOptions[CURLOPT_HTTPHEADER][] = 'Expect:';
         $ch = curl_init();
@@ -117,11 +117,11 @@ class Curl extends Adapter
     /**
      * @inheritdoc
      */
-    public function post($url, array $options = array())
+    public function post($url, array $options = [])
     {
         $this->init($options);
         return $this->send(
-            array(
+            [
                 CURLOPT_URL => $url,
                 CURLOPT_POSTFIELDS => $this->getContent(),
                 CURLOPT_POST => 1,
@@ -129,18 +129,18 @@ class Curl extends Adapter
                 CURLOPT_FRESH_CONNECT => 1,
                 CURLOPT_RETURNTRANSFER => 1,
                 CURLOPT_FORBID_REUSE => 1,
-            )
+            ]
         );
     }
 
     /**
      * @inheritdoc
      */
-    public function put($url, array $options = array())
+    public function put($url, array $options = [])
     {
         $this->init($options);
         return $this->send(
-            array(
+            [
                 CURLOPT_URL => $url,
                 CURLOPT_POSTFIELDS => $this->getContent(),
                 CURLOPT_CUSTOMREQUEST => HttpRequest::METHOD_PUT,
@@ -148,25 +148,25 @@ class Curl extends Adapter
                 CURLOPT_FRESH_CONNECT => 1,
                 CURLOPT_RETURNTRANSFER => 1,
                 CURLOPT_FORBID_REUSE => 1,
-            )
+            ]
         );
     }
 
     /**
      * @inheritdoc
      */
-    public function delete($url, array $options = array())
+    public function delete($url, array $options = [])
     {
         $this->init($options);
         return $this->send(
-            array(
+            [
                 CURLOPT_URL => $url,
                 CURLOPT_CUSTOMREQUEST => HttpRequest::METHOD_DELETE,
                 CURLOPT_HEADER => 1,
                 CURLOPT_FRESH_CONNECT => 1,
                 CURLOPT_RETURNTRANSFER => 1,
                 CURLOPT_FORBID_REUSE => 1,
-            )
+            ]
         );
     }
 }

--- a/src/Request/Http/Adapter/Socket.php
+++ b/src/Request/Http/Adapter/Socket.php
@@ -73,19 +73,19 @@ class Socket extends Adapter
     /**
      * @inheritdoc
      */
-    public function get($url, array $options = array())
+    public function get($url, array $options = [])
     {
         $this->init($options);
         return $this->send(
             $url,
-            array(
-                self::HTTP => array(
+            [
+                self::HTTP => [
                     self::METHOD => HttpRequest::METHOD_GET,
                     self::HEADER => implode(self::CRLF, $this->getHeaders()),
                     // Fetch the content even on failure status codes.
                     self::IGNORE => true,
-                ),
-            )
+                ],
+            ]
         );
     }
 
@@ -109,7 +109,7 @@ class Socket extends Adapter
         // populated into $headers, which is only available in the local scope where file_get_contents()
         // is executed (http://php.net/manual/en/reserved.variables.httpresponseheader.php).
         /** @noinspection PhpVariableNamingConventionInspection */
-        $http_response_header = array();
+        $http_response_header = [];
         $result = @file_get_contents($url, false, $context);
         return new HttpResponse($http_response_header, $result);
     }
@@ -117,59 +117,59 @@ class Socket extends Adapter
     /**
      * @inheritdoc
      */
-    public function post($url, array $options = array())
+    public function post($url, array $options = [])
     {
         $this->init($options);
         return $this->send(
             $url,
-            array(
-                self::HTTP => array(
+            [
+                self::HTTP => [
                     self::METHOD => HttpRequest::METHOD_POST,
                     self::HEADER => implode(self::CRLF, $this->getHeaders()),
                     self::CONTENT => $this->getContent(),
                     // Fetch the content even on failure status codes.
                     self::IGNORE => true,
-                ),
-            )
+                ],
+            ]
         );
     }
 
     /**
      * @inheritdoc
      */
-    public function put($url, array $options = array())
+    public function put($url, array $options = [])
     {
         $this->init($options);
         return $this->send(
             $url,
-            array(
-                self::HTTP => array(
+            [
+                self::HTTP => [
                     self::METHOD => HttpRequest::METHOD_PUT,
                     self::HEADER => implode(self::CRLF, $this->getHeaders()),
                     self::CONTENT => $this->getContent(),
                     // Fetch the content even on failure status codes.
                     self::IGNORE => true,
-                ),
-            )
+                ],
+            ]
         );
     }
 
     /**
      * @inheritdoc
      */
-    public function delete($url, array $options = array())
+    public function delete($url, array $options = [])
     {
         $this->init($options);
         return $this->send(
             $url,
-            array(
-                self::HTTP => array(
+            [
+                self::HTTP => [
                     self::METHOD => HttpRequest::METHOD_DELETE,
                     self::HEADER => implode(self::CRLF, $this->getHeaders()),
                     // Fetch the content even on failure status codes.
                     self::IGNORE => true,
-                ),
-            )
+                ],
+            ]
         );
     }
 }

--- a/src/Request/Http/HttpRequest.php
+++ b/src/Request/Http/HttpRequest.php
@@ -94,7 +94,7 @@ class HttpRequest
     /**
      * @var array list of headers to include in the requests.
      */
-    private $headers = array();
+    private $headers = [];
 
     /**
      * @var string the request content (populated in post() and put() methods).
@@ -104,12 +104,12 @@ class HttpRequest
     /**
      * @var array list of optional query params that are added to the request url.
      */
-    private $queryParams = array();
+    private $queryParams = [];
 
     /**
      * @var array list of optional replace params that can be injected into the url if it contains placeholders.
      */
-    private $replaceParams = array();
+    private $replaceParams = [];
 
     /**
      * @var Adapter the adapter to use for making the request.
@@ -193,7 +193,7 @@ class HttpRequest
     public static function parseQueryString($queryString)
     {
         if (empty($queryString)) {
-            return array();
+            return [];
         }
         parse_str($queryString, $parsedQueryString);
         return $parsedQueryString;
@@ -347,7 +347,7 @@ class HttpRequest
      */
     public function setAuthBasic($username, $password)
     {
-        $this->setAuth(self::AUTH_BASIC, array($username, $password));
+        $this->setAuth(self::AUTH_BASIC, [$username, $password]);
     }
 
     /**
@@ -444,10 +444,10 @@ class HttpRequest
 
         return $this->adapter->post(
             $url,
-            array(
+            [
                 self::HEADERS => $this->headers,
                 self::CONTENT => $this->content,
-            )
+            ]
         );
     }
 
@@ -471,7 +471,7 @@ class HttpRequest
      */
     public static function buildUri($uri, array $replaceParams)
     {
-        $encoded = array();
+        $encoded = [];
         foreach ($replaceParams as $index => $param) {
             $encoded[$index] = urlencode($param);
         }
@@ -496,10 +496,10 @@ class HttpRequest
 
         return $this->adapter->put(
             $url,
-            array(
+            [
                 self::HEADERS => $this->headers,
                 self::CONTENT => $this->content,
-            )
+            ]
         );
     }
 
@@ -522,9 +522,9 @@ class HttpRequest
 
         return $this->adapter->get(
             $url,
-            array(
+            [
                 self::HEADERS => $this->headers,
-            )
+            ]
         );
     }
 
@@ -544,9 +544,9 @@ class HttpRequest
 
         return $this->adapter->delete(
             $url,
-            array(
+            [
                 self::HEADERS => $this->headers,
-            )
+            ]
         );
     }
 
@@ -599,11 +599,11 @@ class HttpRequest
             $url = self::buildUri($url, $this->replaceParams);
         }
         return serialize(
-            array(
+            [
                 self::URL => $url,
                 self::HEADERS => $this->headers,
                 self::BODY => $this->content,
-            )
+            ]
         );
     }
 }

--- a/src/Request/Http/HttpResponse.php
+++ b/src/Request/Http/HttpResponse.php
@@ -134,7 +134,7 @@ class HttpResponse
         $contentType = '';
         if (!empty($this->headers)) {
             foreach ($this->headers as $header) {
-                $matches = array();
+                $matches = [];
                 preg_match('/content-type: (\S*\/\S*)+;/i', $header, $matches);
                 if (isset($matches[1])) {
                     $contentType = $matches[1];
@@ -155,7 +155,7 @@ class HttpResponse
             $code = 0;
             if (!empty($this->headers)) {
                 foreach ($this->headers as $header) {
-                    $matches = array();
+                    $matches = [];
                     preg_match('|HTTP/\d(\.\d)?\s+(\d+)(\s+.*)?|', $header, $matches);
                     if (isset($matches[2])) {
                         $code = (int)$matches[2];
@@ -198,11 +198,11 @@ class HttpResponse
     public function __toString()
     {
         return serialize(
-            array(
+            [
                 'headers' => $this->headers,
                 'body' => $this->result,
                 'error' => $this->message,
-            )
+            ]
         );
     }
 }

--- a/src/Result/Graphql/Recommendation/ResultItem.php
+++ b/src/Result/Graphql/Recommendation/ResultItem.php
@@ -46,9 +46,9 @@ class ResultItem
     /**
      * @var array
      */
-    private $data = array();
+    private $data = [];
 
-    public function __construct(array $data = array())
+    public function __construct(array $data = [])
     {
         $this->data = $data;
     }

--- a/src/Util/Reflection.php
+++ b/src/Util/Reflection.php
@@ -56,15 +56,15 @@ class Reflection
      */
     public static function getObjectProperties($obj)
     {
-        $properties = array();
+        $properties = [];
         try {
             $rc = new \ReflectionClass($obj);
             do {
-                $rp = array();
+                $rp = [];
 
                 // Note that we will not include any properties in traits
                 $traits = $rc->getTraits();
-                $skipProperties = array();
+                $skipProperties = [];
                 if (!empty($traits)) {
                     foreach ($traits as $trait) {
                         foreach ($trait->getProperties() as $traitProperty) {
@@ -105,7 +105,7 @@ class Reflection
             throw new NostoException('Cannot parse methods for non-object');
         }
         $class = new \ReflectionClass($object);
-        $methods = array();
+        $methods = [];
         foreach ($class->getProperties() as $property) {
             $setterName = null;
             $getterName = null;
@@ -124,7 +124,7 @@ class Reflection
                 }
             }
             if ($setterName && $getterName) {
-                $methods[] = array(self::GETTER_KEY => $getterName, self::SETTER_KEY => $setterName);
+                $methods[] = [self::GETTER_KEY => $getterName, self::SETTER_KEY => $setterName];
             }
         }
         return $methods;

--- a/tests/_support/MockIframe.php
+++ b/tests/_support/MockIframe.php
@@ -50,7 +50,7 @@ class MockIframe extends Iframe
         $this->setPreviewUrlCart('http://shop.com/cart?nostodebug=true');
         $this->setPreviewUrlFront('http://shop.com?nostodebug=true');
         $this->setShopName('Shop Name');
-        $this->setModules(array('yotpo', 'klarna'));
+        $this->setModules(['yotpo', 'klarna']);
         $this->setFirstName('James');
         $this->setLastName('Kirk');
         $this->setEmail('james.kirk@example.com');

--- a/tests/_support/MockOAuth.php
+++ b/tests/_support/MockOAuth.php
@@ -46,7 +46,7 @@ class MockOAuth extends OAuth
         $this->setClientId('client-id');
         $this->setClientSecret('client-secret');
         $this->setRedirectUrl('http://my.shop.com/nosto/oauth');
-        $this->setScopes(array('sso', 'products'));
+        $this->setScopes(['sso', 'products']);
         $this->setLanguageIsoCode('en');
     }
 }

--- a/tests/_support/MockOrder.php
+++ b/tests/_support/MockOrder.php
@@ -46,7 +46,7 @@ class MockOrder extends Order
         $this->setCreatedAt(\DateTime::createFromFormat('Y-m-d H:i:s', '2014-12-12 10:15:15'));
         $this->setPaymentProvider('test-gateway [1.0.0]');
         $this->setCustomer(new MockBuyer());
-        $this->setPurchasedItems(array(new MockLineItem(), new MockPseudoItem()));
+        $this->setPurchasedItems([new MockLineItem(), new MockPseudoItem()]);
         $this->setOrderStatus(new MockOrderStatus());
         $this->setExternalOrderRef('ext ref');
         $this->setOrderNumber("123");

--- a/tests/_support/MockProduct.php
+++ b/tests/_support/MockProduct.php
@@ -45,9 +45,9 @@ class MockProduct extends Product
     {
         parent::__construct();
         $this->setDescription('This is a full description');
-        $this->setTag1(array('first'));
-        $this->setTag2(array('second'));
-        $this->setTag3(array('third'));
+        $this->setTag1(['first']);
+        $this->setTag2(['second']);
+        $this->setTag3(['third']);
         $this->setUrl('http://my.shop.com/products/test_product.html');
         $this->setProductId(1);
         $this->setName('Test Product');
@@ -55,7 +55,7 @@ class MockProduct extends Product
         $this->setPrice(99.99);
         $this->setPriceCurrencyCode('USD');
         $this->setAvailability('InStock');
-        $this->setCategories(array('/Mens', '/Mens/Shoes'));
+        $this->setCategories(['/Mens', '/Mens/Shoes']);
         $this->setListPrice(110.99);
         $this->setBrand('Super Brand');
         $this->setVariationId("USD");
@@ -63,7 +63,7 @@ class MockProduct extends Product
         $this->setInventoryLevel(50);
         $this->setReviewCount(99);
         $this->setRatingValue(2.5);
-        $urls = array("http://shop.com/product_alt.jpg");
+        $urls = ["http://shop.com/product_alt.jpg"];
         $this->setAlternateImageUrls($urls);
         $this->setCondition("Used");
         $this->setGtin("gtin");

--- a/tests/unit/HttpRequestTest.php
+++ b/tests/unit/HttpRequestTest.php
@@ -57,10 +57,10 @@ class HttpRequestTest extends Test
     public function testHttpRequestQueryParams()
     {
         $request = new HttpRequest();
-        $request->setQueryParams(array(
+        $request->setQueryParams([
             'param1' => 'first',
             'param2' => 'second',
-        ));
+        ]);
         $params = $request->getQueryParams();
         $this->assertArrayHasKey('param1', $params);
         $this->assertContains('first', $params);
@@ -77,7 +77,7 @@ class HttpRequestTest extends Test
         $request->setAuthBasic('test', 'test');
         $headers = $request->getHeaders();
         $this->assertContains(
-            'Authorization: Basic ' . base64_encode(implode(':', array('test', 'test')))
+            'Authorization: Basic ' . base64_encode(implode(':', ['test', 'test']))
             , $headers
         );
     }
@@ -141,10 +141,10 @@ class HttpRequestTest extends Test
                 'http://localhost:%d?param1={p1}&param2={p2}',
                 self::CURL_TEST_PORT
             ),
-            array(
+            [
                 '{p1}' => 'first',
                 '{p2}' => 'second'
-            )
+            ]
         );
         $this->assertEquals(
             sprintf(
@@ -231,7 +231,7 @@ class HttpRequestTest extends Test
      */
     public function testHttpRequestResponseResult()
     {
-        $response = new HttpResponse(array(), json_encode(array('test' => true)));
+        $response = new HttpResponse([], json_encode(['test' => true]));
         $this->assertEquals('{"test":true}', $response->getResult());
         $result = $response->getJsonResult(true);
         $this->assertArrayHasKey('test', $result);
@@ -243,7 +243,7 @@ class HttpRequestTest extends Test
      */
     public function testHttpRequestResponseErrorMessage()
     {
-        $response = new HttpResponse(array(), '', 'error');
+        $response = new HttpResponse([], '', 'error');
         $this->assertEquals('error', $response->getMessage());
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Replace `array` syntax with short array syntax.

## Related Issue
N/A

## Motivation and Context
Since this PHP package requires `php-5.4` version at least, the short array syntax is available on `php-5.4` version now.

## How Has This Been Tested?
It's syntax changes, and it should not be tested.

## Documentation:
N/A

## Checklist:
- [ X ] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
