### PR TITLE
Fix the recommendation result set parsing when resultId is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+## 5.1.1
+* Handle recommendation response parsing without resultId
+
 ## 5.1.0
 * Upgrade vlucas/phpdotenv to support versions up to 3.6
 

--- a/src/.env
+++ b/src/.env
@@ -1,7 +1,1 @@
-NOSTO_SERVER_URL=connect.nosto.com
-NOSTO_EMAIL_WIDGET_BASE_URL=https://connect.nosto.com
-NOSTO_API_BASE_URL=https://api.nosto.com
-NOSTO_OAUTH_BASE_URL=https://my.nosto.com/oauth
-NOSTO_WEB_HOOK_BASE_URL=https://my.nosto.com
-NOSTO_IFRAME_ORIGIN_REGEXP=(https:\/\/(.*)\.hub\.nosto\.com)|(https:\/\/my\.nosto\.com)
-NOSTO_GRAPHQL_BASE_URL=https://api.nosto.com
+/Users/hannu.polonen/Sites/Libs/.env-my-dev

--- a/src/.env
+++ b/src/.env
@@ -1,1 +1,7 @@
-/Users/hannu.polonen/Sites/Libs/.env-my-dev
+NOSTO_SERVER_URL=connect.nosto.com
+NOSTO_EMAIL_WIDGET_BASE_URL=https://connect.nosto.com
+NOSTO_API_BASE_URL=https://api.nosto.com
+NOSTO_OAUTH_BASE_URL=https://my.nosto.com/oauth
+NOSTO_WEB_HOOK_BASE_URL=https://my.nosto.com
+NOSTO_IFRAME_ORIGIN_REGEXP=(https:\/\/(.*)\.hub\.nosto\.com)|(https:\/\/my\.nosto\.com)
+NOSTO_GRAPHQL_BASE_URL=https://api.nosto.com

--- a/src/Result/Graphql/Recommendation/RecommendationResultHandler.php
+++ b/src/Result/Graphql/Recommendation/RecommendationResultHandler.php
@@ -55,7 +55,11 @@ class RecommendationResultHandler extends GraphQLResultHandler
         /** @var \stdClass $categoryData */
         $categoryData = self::parseData($stdClass, self::GRAPHQL_DATA_CATEGORY);
         /** @var string $trackingCode */
-        $trackingCode = self::parseData($categoryData, self::GRAPHQL_DATA_RESULT_ID);
+        try {
+            $trackingCode = self::parseData($categoryData, self::GRAPHQL_DATA_RESULT_ID);
+        } catch (NostoException $e) { // Tracking code is not present when feature (like CMP) is not active
+            $trackingCode = '';
+        }
         /** @var int $totalPrimaryCount */
         $totalPrimaryCount = self::parseData($categoryData, self::GRAPHQL_DATA_PRIMARY_COUNT);
         /** @var ResultSet $resultSet */

--- a/tests/unit/Result/GraphqlCMPTest.php
+++ b/tests/unit/Result/GraphqlCMPTest.php
@@ -120,4 +120,22 @@ class GraphqlCMPTest extends Test
             }
         });
     }
+
+    /**
+     * Tests that no exception is thrown when result id is missing
+     */
+    public function testBuildingResponseForMissing()
+    {
+        $responseBody = '{ "data": { "session": { "id": "5d481e38c10ea0f265eb2f5c", "recos": { "category": { "primary": [], "totalPrimaryCount": 0 } } } } }';
+        $response = new HttpResponse(['HTTP/1.1 200 OK'], $responseBody);
+        $request = new HttpRequest();
+        $request->setResultHandler(new RecommendationResultHandler());
+
+        /** @var CategoryMerchandisingResult $resultSet */
+        $resultSet = $request->getResultHandler()->parse($response);
+
+        $this->specify('result does not contain resultId', function () use ($resultSet) {
+            $this->assertEquals($resultSet->getResultSet()->count(), 0);
+        });
+    }
 }


### PR DESCRIPTION
## Description
Handle gracefully recommendation responses that don't have result id in response.

## Related Issue
#278 

## Motivation and Context
We should not throw an exception for a normal response. If there are no results (for example for CMP) it's not a error but most likely a category that has not been configured to have CMP. 

## How Has This Been Tested?
* Added a unit test
* Tested locally with M2 CMP

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
