### PR TITLE
Support batched category merchandising calls 

### DIFF
--- a/PHP-SDK.iml
+++ b/PHP-SDK.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Nosto\" />
       <excludeFolder url="file://$MODULE_DIR$/.github" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />

--- a/src/Operation/Recommendation/AbstractRecommendation.php
+++ b/src/Operation/Recommendation/AbstractRecommendation.php
@@ -45,7 +45,7 @@ use Nosto\Types\Signup\AccountInterface;
  */
 abstract class AbstractRecommendation extends AbstractGraphQLOperation
 {
-    const LIMIT = 10;
+    const DEFAULT_LIMIT = 10;
 
     /** @var bool $previewMode */
     protected $previewMode;
@@ -74,7 +74,7 @@ abstract class AbstractRecommendation extends AbstractGraphQLOperation
         $activeDomain = '',
         $customerBy = self::IDENTIFIER_BY_CID,
         $previewMode = false,
-        $limit = self::LIMIT
+        $limit = self::DEFAULT_LIMIT
     ) {
         $this->limit = $limit;
         $this->customerBy = $customerBy;

--- a/src/Operation/Recommendation/BatchedCategoryMerchandising.php
+++ b/src/Operation/Recommendation/BatchedCategoryMerchandising.php
@@ -124,6 +124,14 @@ class BatchedCategoryMerchandising
      */
     public function execute()
     {
+        if ($this->limit === 0 || !is_numeric($this->limit)) {
+            throw new NostoException(
+                sprintf(
+                    'Invalid limit %s given for CMP batching',
+                    $this->limit
+                )
+            );
+        }
         $batchCount = 1;
         $limit = $this->limit;
         if ($this->limit >= self::HARD_LIMIT) {

--- a/src/Operation/Recommendation/BatchedCategoryMerchandising.php
+++ b/src/Operation/Recommendation/BatchedCategoryMerchandising.php
@@ -36,10 +36,17 @@
 
 namespace Nosto\Operation\Recommendation;
 
+use Nosto\NostoException;
+use Nosto\Request\Http\Exception\AbstractHttpException;
+use Nosto\Request\Http\Exception\HttpResponseException;
+use Nosto\Result\Graphql\Recommendation\CategoryMerchandisingResult;
 use Nosto\Types\Signup\AccountInterface;
+use Nosto\Util\Recommendation;
 
-class CategoryMerchandising extends AbstractRecommendation
+class BatchedCategoryMerchandising
 {
+    const HARD_LIMIT = 250;
+
     /** @var string $category */
     private $category;
 
@@ -51,6 +58,24 @@ class CategoryMerchandising extends AbstractRecommendation
 
     /** @var int */
     private $skipPages;
+
+    /** @var AccountInterface */
+    private $account;
+
+    /** @var string */
+    private $customerId;
+
+    /** @var string */
+    private $activeDomain;
+
+    /** @var string */
+    private $customerBy;
+
+    /** @var bool */
+    private $previewMode;
+
+    /** @var int */
+    private $limit;
 
     /**
      * CategoryMerchandising constructor.
@@ -73,78 +98,60 @@ class CategoryMerchandising extends AbstractRecommendation
         IncludeFilters $includeFilters,
         ExcludeFilters $excludeFilters,
         $activeDomain = '',
-        $customerBy = self::IDENTIFIER_BY_CID,
+        $customerBy = CategoryMerchandising::IDENTIFIER_BY_CID,
         $previewMode = false,
-        $limit = self::DEFAULT_LIMIT
+        $limit = CategoryMerchandising::DEFAULT_LIMIT
     ) {
         $this->category = $category;
         $this->skipPages = $skipPages;
         $this->includeFilters = $includeFilters;
         $this->excludeFilters = $excludeFilters;
-        parent::__construct($account, $customerId, $activeDomain, $customerBy, $previewMode, $limit);
+        $this->account = $account;
+        $this->customerId = $customerId;
+        $this->activeDomain = $activeDomain;
+        $this->customerBy = $customerBy;
+        $this->previewMode = $previewMode;
+        $this->limit = $limit;
     }
 
     /**
-     * @inheritdoc
+     * Splits category merchandising calls based on hard limit (250) and given limit
+     *
+     * @return CategoryMerchandisingResult
+     * @throws AbstractHttpException
+     * @throws HttpResponseException
+     * @throws NostoException
      */
-    public function getQuery()
+    public function execute()
     {
-        return <<<QUERY
-            query(
-                \$customerId: String!,
-                \$category: String!,
-                \$limit: Int!,
-                \$preview: Boolean!,
-                \$by: LookupParams!,
-                \$skipPages: Int,
-                \$includeFilters: InputIncludeParams,
-                \$excludeFilters: InputFilterParams
-            ) {
-              session (
-                id: \$customerId,
-                by: \$by,
-              ) {
-                id
-                recos (preview: \$preview, image: VERSION_10_MAX_SQUARE) {
-                  category (
-                    category: \$category
-                    minProducts: 1
-                    maxProducts: \$limit,
-                    skipPages: \$skipPages,
-                    include: \$includeFilters,
-                    exclude: \$excludeFilters,
-                    skipVCEvent: true
-                  ) {
-                    primary {
-                      productId
-                      priceText
-                      name
-                      imageUrl
-                    }
-                    batchToken
-                    totalPrimaryCount
-                    resultId
-                  }
-                }
-              }
+        $batchCount = 1;
+        $limit = $this->limit;
+        if ($this->limit >= self::HARD_LIMIT) {
+            $batchCount = ceil($this->limit / self::HARD_LIMIT);
+            $limit = self::HARD_LIMIT;
+        }
+        $responses = [];
+        for ($x=0; $x < $batchCount; $x++) {
+            $categoryMerchandising = new CategoryMerchandising(
+                $this->account,
+                $this->customerId,
+                $this->category,
+                $x,
+                $this->includeFilters,
+                $this->excludeFilters,
+                $this->activeDomain,
+                $this->customerBy,
+                $this->previewMode,
+                $limit
+            );
+            /** @var CategoryMerchandisingResult $response */
+            $response = $categoryMerchandising->execute();
+            $responses[] = $response;
+            if ($response->getResultSet()->count() === 0) {
+                break;
             }
-QUERY;
-    }
+        }
 
-    /**
-     * @inheritdoc
-     */
-    public function getVariables()
-    {
-        return [
-            'customerId' => $this->customerId,
-            'category' => $this->category,
-            'limit' => $this->limit,
-            'preview' => $this->previewMode,
-            'by' => $this->customerBy,
-            'skipPages' => $this->skipPages,
-            'includeFilters' => $this->includeFilters->toArray(),
-            'excludeFilters' => $this->excludeFilters->toArray()
-        ];
+        return Recommendation::mergeCategoryMerchandisingResults($responses);
     }
 }

--- a/src/Operation/Recommendation/BatchedCategoryMerchandising.php
+++ b/src/Operation/Recommendation/BatchedCategoryMerchandising.php
@@ -132,7 +132,7 @@ class BatchedCategoryMerchandising
         }
         $responses = [];
         for ($x=0; $x < $batchCount; $x++) {
-            $categoryMerchandising = new CategoryMerchandising(
+            $catMerchandising = new CategoryMerchandising(
                 $this->account,
                 $this->customerId,
                 $this->category,
@@ -145,7 +145,7 @@ class BatchedCategoryMerchandising
                 $limit
             );
             /** @var CategoryMerchandisingResult $response */
-            $response = $categoryMerchandising->execute();
+            $response = $catMerchandising->execute();
             $responses[] = $response;
             if ($response->getResultSet()->count() === 0) {
                 break;

--- a/src/Util/Recommendation.php
+++ b/src/Util/Recommendation.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Util;
+
+use Nosto\Result\Graphql\Recommendation\CategoryMerchandisingResult;
+use Nosto\Result\Graphql\Recommendation\ResultSet;
+
+class Recommendation
+{
+    /**
+     * Combines multiple recommendation result sets into a single result set
+     * @param CategoryMerchandisingResult[] $results
+     * @return CategoryMerchandisingResult
+     */
+    public static function mergeCategoryMerchandisingResults(array $results)
+    {
+        $combinedResultSet = new ResultSet();
+        $count = 0;
+        foreach ($results as $result) {
+            foreach ($result->getResultSet() as $item) {
+                $combinedResultSet->append($item);
+                ++$count;
+            }
+        }
+        return new CategoryMerchandisingResult($combinedResultSet, $result->getTrackingCode(), $count);
+    }
+}

--- a/src/Util/Recommendation.php
+++ b/src/Util/Recommendation.php
@@ -50,12 +50,17 @@ class Recommendation
     {
         $combinedResultSet = new ResultSet();
         $count = 0;
+        $firstResult = reset($results);
+        $trackingCode = 'not-defined';
+        if ($firstResult !== null) {
+            $trackingCode = $firstResult->getTrackingCode();
+        }
         foreach ($results as $result) {
             foreach ($result->getResultSet() as $item) {
                 $combinedResultSet->append($item);
                 ++$count;
             }
         }
-        return new CategoryMerchandisingResult($combinedResultSet, $result->getTrackingCode(), $count);
+        return new CategoryMerchandisingResult($combinedResultSet, $trackingCode, $count);
     }
 }


### PR DESCRIPTION
## Description
Introduce new service / operation for batching the CMP calls to around the limitation of max 250 products. 

## Related Issue
#286 

## Motivation and Context
On some category pages all products in a category can be viewed and we must be able to return all products in the category from Nosto.  

## How Has This Been Tested?
Tested locally with several limits.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
