### PR TITLE
Add batchToken to GraphQl

### DIFF
--- a/src/Operation/Recommendation/CategoryMerchandising.php
+++ b/src/Operation/Recommendation/CategoryMerchandising.php
@@ -52,6 +52,9 @@ class CategoryMerchandising extends AbstractRecommendation
     /** @var int */
     private $skipPages;
 
+    /** @var string */
+    private $batchToken;
+
     /**
      * CategoryMerchandising constructor.
      * @param AccountInterface $account
@@ -75,12 +78,14 @@ class CategoryMerchandising extends AbstractRecommendation
         $activeDomain = '',
         $customerBy = self::IDENTIFIER_BY_CID,
         $previewMode = false,
-        $limit = self::LIMIT
+        $limit = self::LIMIT,
+        $batchToken = ''
     ) {
         $this->category = $category;
         $this->skipPages = $skipPages;
         $this->includeFilters = $includeFilters;
         $this->excludeFilters = $excludeFilters;
+        $this->batchToken = $batchToken;
         parent::__construct($account, $customerId, $activeDomain, $customerBy, $previewMode, $limit);
     }
 
@@ -98,7 +103,8 @@ class CategoryMerchandising extends AbstractRecommendation
                 \$by: LookupParams!,
                 \$skipPages: Int,
                 \$includeFilters: InputIncludeParams,
-                \$excludeFilters: InputFilterParams
+                \$excludeFilters: InputFilterParams,
+                \$batchToken: String
             ) {
               session (
                 id: \$customerId,
@@ -113,7 +119,8 @@ class CategoryMerchandising extends AbstractRecommendation
                     skipPages: \$skipPages,
                     include: \$includeFilters,
                     exclude: \$excludeFilters,
-                    skipVCEvent: true
+                    skipVCEvent: true,
+                    batchToken: \$batchToken
                   ) {
                     primary {
                       productId
@@ -146,5 +153,13 @@ QUERY;
             'includeFilters' => $this->includeFilters->toArray(),
             'excludeFilters' => $this->excludeFilters->toArray()
         ];
+    }
+
+    /**
+     * @param string $batchToken
+     */
+    public function setBatchToken($batchToken)
+    {
+        $this->batchToken = $batchToken;
     }
 }

--- a/src/Operation/Recommendation/CategoryMerchandising.php
+++ b/src/Operation/Recommendation/CategoryMerchandising.php
@@ -150,12 +150,13 @@ QUERY;
             'limit' => $this->limit,
             'preview' => $this->previewMode,
             'by' => $this->customerBy,
-            'skipPages' => $this->skipPages,
             'includeFilters' => $this->includeFilters->toArray(),
             'excludeFilters' => $this->excludeFilters->toArray()
         ];
         if ($this->batchToken !== '') {
             $variables['batchToken'] = $this->batchToken;
+        } else {
+            $variables['skipPages'] = $this->skipPages;
         }
         return $variables;
     }

--- a/src/Operation/Recommendation/CategoryMerchandising.php
+++ b/src/Operation/Recommendation/CategoryMerchandising.php
@@ -144,7 +144,7 @@ QUERY;
      */
     public function getVariables()
     {
-        return [
+        $variables = [
             'customerId' => $this->customerId,
             'category' => $this->category,
             'limit' => $this->limit,
@@ -154,6 +154,10 @@ QUERY;
             'includeFilters' => $this->includeFilters->toArray(),
             'excludeFilters' => $this->excludeFilters->toArray()
         ];
+        if ($this->batchToken !== '') {
+            $variables['batchToken'] = $this->batchToken;
+        }
+        return $variables;
     }
 
     /**

--- a/src/Operation/Recommendation/CategoryMerchandising.php
+++ b/src/Operation/Recommendation/CategoryMerchandising.php
@@ -67,6 +67,7 @@ class CategoryMerchandising extends AbstractRecommendation
      * @param string $customerBy
      * @param bool $previewMode
      * @param int $limit
+     * @param string $batchToken
      */
     public function __construct(
         AccountInterface $account,

--- a/src/Result/Graphql/Recommendation/CategoryMerchandisingResult.php
+++ b/src/Result/Graphql/Recommendation/CategoryMerchandisingResult.php
@@ -53,9 +53,9 @@ class CategoryMerchandisingResult
     /**
      * CategoryMerchandisingResult constructor.
      * @param ResultSet $resultSet
-     * @param $trackingCode
-     * @param $totalPrimaryCount
-     * @param $batchToken
+     * @param string $trackingCode
+     * @param int $totalPrimaryCount
+     * @param string $batchToken
      */
     public function __construct(
         ResultSet $resultSet,

--- a/src/Result/Graphql/Recommendation/CategoryMerchandisingResult.php
+++ b/src/Result/Graphql/Recommendation/CategoryMerchandisingResult.php
@@ -47,22 +47,28 @@ class CategoryMerchandisingResult
     /** @var int $totalPrimaryCount */
     private $totalPrimaryCount;
 
+    /** @var string $batchToken */
+    private $batchToken;
+
     /**
      * CategoryMerchandisingResult constructor.
      * @param ResultSet $resultSet
-     * @param string $trackingCode
-     * @param int $totalPrimaryCount
+     * @param $trackingCode
+     * @param $totalPrimaryCount
+     * @param $batchToken
      */
     public function __construct(
         ResultSet $resultSet,
         $trackingCode,
-        $totalPrimaryCount
+        $totalPrimaryCount,
+        $batchToken
     ) {
         $this->resultSet = $resultSet;
         $this->trackingCode = $trackingCode;
         $this->totalPrimaryCount = $totalPrimaryCount;
+        $this->batchToken = $batchToken;
     }
-    
+
     /**
      * @return ResultSet
      */
@@ -85,5 +91,13 @@ class CategoryMerchandisingResult
     public function getTotalPrimaryCount()
     {
         return $this->totalPrimaryCount;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBatchToken()
+    {
+        return $this->batchToken;
     }
 }

--- a/src/Result/Graphql/Recommendation/RecommendationResultHandler.php
+++ b/src/Result/Graphql/Recommendation/RecommendationResultHandler.php
@@ -47,6 +47,7 @@ class RecommendationResultHandler extends GraphQLResultHandler
     const GRAPHQL_DATA_CATEGORY = 'category';
     const GRAPHQL_DATA_RESULT_ID = 'resultId';
     const GRAPHQL_DATA_PRIMARY_COUNT = 'totalPrimaryCount';
+    const GRAPHQL_DATA_BATCH_TOKEN = 'batchToken';
 
     /**
      * @inheritdoc
@@ -63,11 +64,13 @@ class RecommendationResultHandler extends GraphQLResultHandler
         }
         /** @var int $totalPrimaryCount */
         $totalPrimaryCount = self::parseData($categoryData, self::GRAPHQL_DATA_PRIMARY_COUNT);
+        $batchToken = self::parseData($categoryData, self::GRAPHQL_DATA_BATCH_TOKEN);
         $resultSet = self::buildResultSet($categoryData);
         return new CategoryMerchandisingResult(
             $resultSet,
             $trackingCode,
-            $totalPrimaryCount
+            $totalPrimaryCount,
+            $batchToken
         );
     }
 

--- a/src/Util/Recommendation.php
+++ b/src/Util/Recommendation.php
@@ -61,6 +61,6 @@ class Recommendation
                 ++$count;
             }
         }
-        return new CategoryMerchandisingResult($combinedResultSet, $trackingCode, $count);
+        return new CategoryMerchandisingResult($combinedResultSet, $trackingCode, $count, '');
     }
 }

--- a/tests/unit/Result/GraphqlCMPTest.php
+++ b/tests/unit/Result/GraphqlCMPTest.php
@@ -129,7 +129,7 @@ class GraphqlCMPTest extends Test
      */
     public function testBuildingResponseForMissing()
     {
-        $responseBody = '{ "data": { "session": { "id": "5d481e38c10ea0f265eb2f5c", "recos": { "category": { "primary": [], "totalPrimaryCount": 0 } } } } }';
+        $responseBody = '{ "data": { "session": { "id": "5d481e38c10ea0f265eb2f5c", "recos": { "category": { "primary": [], "batchToken": null,     "totalPrimaryCount": 0 } } } } }';
         $response = new HttpResponse(['HTTP/1.1 200 OK'], $responseBody);
         $request = new HttpRequest();
         $request->setResultHandler(new RecommendationResultHandler());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The time of response of the GraphQl call will increase when paginating. To overcome this issue, the batchToken that is return from the current page, can be passed to the next call. 

In this change, a method to add batchTokeb to the `CategoryMerchandising` object. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
