### PR TITLE
Add batch token to batched CMP calls

### DIFF
--- a/src/Operation/Recommendation/BatchedCategoryMerchandising.php
+++ b/src/Operation/Recommendation/BatchedCategoryMerchandising.php
@@ -139,6 +139,8 @@ class BatchedCategoryMerchandising
             $limit = self::HARD_LIMIT;
         }
         $responses = [];
+        $batchToken = '';
+        $totalFetched = 0;
         for ($x=0; $x < $batchCount; $x++) {
             $catMerchandising = new CategoryMerchandising(
                 $this->account,
@@ -150,12 +152,16 @@ class BatchedCategoryMerchandising
                 $this->activeDomain,
                 $this->customerBy,
                 $this->previewMode,
-                $limit
+                $limit,
+                $batchToken
             );
             /** @var CategoryMerchandisingResult $response */
             $response = $catMerchandising->execute();
             $responses[] = $response;
-            if ($response->getResultSet()->count() === 0) {
+            $batchToken = $response->getBatchToken();
+            $responseCount = $response->getResultSet()->count();
+            $totalFetched += $responseCount;
+            if ($responseCount === 0 || $totalFetched === $response->getTotalPrimaryCount()) {
                 break;
             }
         }

--- a/src/Util/Recommendation.php
+++ b/src/Util/Recommendation.php
@@ -52,15 +52,17 @@ class Recommendation
         $count = 0;
         $firstResult = reset($results);
         $trackingCode = 'not-defined';
+        $batchToken = '';
         if ($firstResult !== null) {
             $trackingCode = $firstResult->getTrackingCode();
         }
         foreach ($results as $result) {
+            $batchToken = $result->getBatchToken(); // We store the batch token of the last result
             foreach ($result->getResultSet() as $item) {
                 $combinedResultSet->append($item);
                 ++$count;
             }
         }
-        return new CategoryMerchandisingResult($combinedResultSet, $trackingCode, $count, '');
+        return new CategoryMerchandisingResult($combinedResultSet, $trackingCode, $count, $batchToken);
     }
 }


### PR DESCRIPTION
## Description
The batch token is added to the batched CMP calls. 

## Motivation and Context
Batch token speeds up the fetching the CMP results in Nosto's end.  

## How Has This Been Tested?
Tested locally

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
