### PR TITLE
Check if the response content type contains application/json

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -15,7 +15,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.2'
-        tools: composer, prestissimo
+        tools: composer:v1, prestissimo
         extensions: ast
         coverage: none
 

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -65,7 +65,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.2'
-        tools: composer, prestissimo
+        tools: composer:v1, prestissimo
         extensions: ast
         coverage: none
 
@@ -112,7 +112,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.2'
-        tools: composer, prestissimo
+        tools: composer:v1, prestissimo
         extensions: ast
         coverage: none
 
@@ -163,7 +163,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.2'
-        tools: composer, prestissimo
+        tools: composer:v1, prestissimo
         extensions: ast
         coverage: none
 

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -16,7 +16,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.2'
-        tools: composer, prestissimo, pecl
+        tools: composer:v1, prestissimo, pecl
         coverage: none
 
     - name: Install AST extension

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -16,7 +16,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.2'
-        tools: composer, prestissimo, pecl
+        tools: composer:v1, prestissimo, pecl
         coverage: none
 
     - name: Install AST extension

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.2'
-        tools: composer, prestissimo
+        tools: composer:v1, prestissimo
         coverage: none
 
       #https://github.com/actions/cache/blob/master/examples.md#php---composer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+## upcoming
+* Fix error message parsing for application/json type
+
 ## 5.3.3
 * Fix page number for CMP request
 

--- a/src/Util/HttpResponseException.php
+++ b/src/Util/HttpResponseException.php
@@ -49,7 +49,7 @@ class HttpResponseException
      */
     public static function handle(HttpResponse $httpResponse)
     {
-        if ($httpResponse->getContentType() === AbstractOperation::CONTENT_TYPE_APPLICATION_JSON) {
+        if (strpos($httpResponse->getContentType(), AbstractOperation::CONTENT_TYPE_APPLICATION_JSON) !== false) {
             self::handleJson($httpResponse);
         }
         throw new ResponseException(

--- a/src/Util/HttpResponseException.php
+++ b/src/Util/HttpResponseException.php
@@ -51,11 +51,21 @@ class HttpResponseException
     {
         if (strpos($httpResponse->getContentType(), AbstractOperation::CONTENT_TYPE_APPLICATION_JSON) !== false) {
             self::handleJson($httpResponse);
+        } else {
+            self::handlePlainText($httpResponse);
         }
+    }
+
+    /**
+     * @param HttpResponse $httpResponse
+     * @throws ResponseException
+     */
+    private static function handlePlainText(HttpResponse $httpResponse) {
         throw new ResponseException(
             sprintf(
-                'Something went wrong:  %s',
-                $httpResponse->getMessage()
+                'Something went wrong:  %s %s',
+                $httpResponse->getMessage(),
+                self::getXRequestId($httpResponse)
             ),
             $httpResponse->getCode()
         );
@@ -82,7 +92,21 @@ class HttpResponseException
                 }
             }
         }
+        $message .= self::getXRequestId($httpResponse);
         throw new ResponseException($message);
+    }
+
+    /**
+     * @param HttpResponse $httpResponse
+     * @return string|null
+     */
+    private static function getXRequestId(HttpResponse $httpResponse)
+    {
+        if ($httpResponse != null) {
+            return sprintf("{Nosto request id is: %s}: ", $httpResponse->getXRequestId());
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When trying to parse the exception message, the function check if the response type is exactly `application/json`, but it might also contain the utf chatset in the same string. As a result the response message will not be logged. Fix the issue by checking if it contains the string instead. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
