### PR TITLE
Hotfix 5.3.5 - Fix CMP failing when batchToken value is null 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+## 5.3.5
+* Fix CMP throwing exception issue when batchToken value is null
+
 ## 5.3.4
 * Fix error message parsing for application/json type
 

--- a/src/Result/Graphql/Recommendation/RecommendationResultHandler.php
+++ b/src/Result/Graphql/Recommendation/RecommendationResultHandler.php
@@ -62,9 +62,13 @@ class RecommendationResultHandler extends GraphQLResultHandler
         } catch (NostoException $e) { // Tracking code is not present when feature (like CMP) is not active
             $trackingCode = '';
         }
+        try {
+            $batchToken = self::parseData($categoryData, self::GRAPHQL_DATA_BATCH_TOKEN);
+        } catch (NostoException $e) { // Batch token is not present
+            $batchToken = '';
+        }
         /** @var int $totalPrimaryCount */
         $totalPrimaryCount = self::parseData($categoryData, self::GRAPHQL_DATA_PRIMARY_COUNT);
-        $batchToken = self::parseData($categoryData, self::GRAPHQL_DATA_BATCH_TOKEN);
         $resultSet = self::buildResultSet($categoryData);
         return new CategoryMerchandisingResult(
             $resultSet,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When batchToken value is null an exception is thrown by the SDK, and the CMP results are not displayed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
