### PR TITLE
Limit the price float value to 2 decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+### 5.3.8
+* Round product price, list_price and supplier_cost to 2 decimals
+
 ### 5.3.7
 * Update phpseclib and dev dependencies
 

--- a/src/Model/Product/Product.php
+++ b/src/Model/Product/Product.php
@@ -676,7 +676,10 @@ class Product extends AbstractObject implements
      */
     public function setSupplierCost($supplierCost)
     {
-        $this->supplierCost = $supplierCost;
+        //null will be rounded to 0gst
+        if ($supplierCost != null) {
+            $this->supplierCost = round($supplierCost, 2);
+        }
     }
 
     /**

--- a/src/Model/Product/Product.php
+++ b/src/Model/Product/Product.php
@@ -676,9 +676,11 @@ class Product extends AbstractObject implements
      */
     public function setSupplierCost($supplierCost)
     {
-        //null will be rounded to 0gst
+        //null will be rounded to 0
         if ($supplierCost != null) {
             $this->supplierCost = round($supplierCost, 2);
+        } else {
+            $this->supplierCost = null;
         }
     }
 

--- a/src/Model/Product/Product.php
+++ b/src/Model/Product/Product.php
@@ -505,7 +505,7 @@ class Product extends AbstractObject implements
      */
     public function setPrice($price)
     {
-        $this->price = $price;
+        $this->price = round($price, 2);
     }
 
     /**
@@ -602,7 +602,7 @@ class Product extends AbstractObject implements
      */
     public function setListPrice($listPrice)
     {
-        $this->listPrice = $listPrice;
+        $this->listPrice = round($listPrice, 2);
     }
 
     /**

--- a/src/Model/Product/Sku.php
+++ b/src/Model/Product/Sku.php
@@ -171,7 +171,7 @@ class Sku extends AbstractObject implements
      */
     public function setPrice($price)
     {
-        $this->price = $price;
+        $this->price = round($price, 2);
     }
 
     /**
@@ -189,7 +189,7 @@ class Sku extends AbstractObject implements
      */
     public function setListPrice($listPrice)
     {
-        $this->listPrice = $listPrice;
+        $this->listPrice = round($listPrice, 2);
     }
 
     /**

--- a/src/Model/Product/Variation.php
+++ b/src/Model/Product/Variation.php
@@ -119,7 +119,7 @@ class Variation extends AbstractObject implements
      */
     public function setPrice($price)
     {
-        $this->price = $price;
+        $this->price = round($price, 2);
     }
 
     /**
@@ -137,7 +137,7 @@ class Variation extends AbstractObject implements
      */
     public function setListPrice($listPrice)
     {
-        $this->listPrice = $listPrice;
+        $this->listPrice = round($listPrice, 2);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Floating numbers have a maximum precision of 14 digits. When the price exceeds this precision there is a discrepancy between the price value that comes through API (it will be a string and have the correct value) and the one tagged in the product page (will be rounded). 

To fix this, round the price to 2 decimal places. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
