### PR TITLE
Add compatibility for different phpseclib versions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer:v2, prestissimo
         extensions: ast
         coverage: none
@@ -64,7 +64,7 @@ jobs:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer:v2, prestissimo
         extensions: ast
         coverage: none
@@ -111,7 +111,7 @@ jobs:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer:v2, prestissimo
         extensions: ast
         coverage: none
@@ -162,7 +162,7 @@ jobs:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer:v2, prestissimo
         extensions: ast
         coverage: none

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer:v2, prestissimo, pecl
         coverage: none
         extensions: ast, bcmath, gd, pdo_mysql, zip, soap

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer:v2, prestissimo, pecl
         coverage: none
         extensions: ast, bcmath, gd, pdo_mysql, zip, soap

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer:v2, prestissimo
         coverage: none
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
-### 5.8.2
-* Fix compatibility issues with Magento 2.3 (vlucas/phpdotenv and phpseclib/phpseclib)
-
 ### 5.8.1
 * Suppress missing return type for inherit class (Needed to run with PHP 8.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to Semantic Versioning (http://semver.org/).
 
+### 5.8.2
+* Fix compatibility issues with Magento 2.3 (vlucas/phpdotenv and phpseclib/phpseclib)
+
 ### 5.8.1
 * Suppress missing return type for inherit class (Needed to run with PHP 8.1)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "nosto/php-sdk",
-  "version": "5.8.2",
+  "version": "5.8.1",
   "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
   "license": "BSD-3-Clause",
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "require": {
     "php": ">=5.5",
     "phpseclib/phpseclib": "2.0.* || ~3.0.9",
-    "vlucas/phpdotenv": "^2.4 || ^3.6",
+    "vlucas/phpdotenv": ">=2.4.0 <=3.6",
     "ext-json": "*",
     "ext-curl": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "require": {
     "php": ">=5.5",
     "phpseclib/phpseclib": "2.0.* || ~3.0.9",
-    "vlucas/phpdotenv": "^3.6",
+    "vlucas/phpdotenv": "^2.4 || ^3.6",
     "ext-json": "*",
     "ext-curl": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   },
   "require": {
     "php": ">=5.5",
-    "phpseclib/phpseclib": "~3.0.9",
+    "phpseclib/phpseclib": "2.0.* || ~3.0.9",
     "vlucas/phpdotenv": "^3.6",
     "ext-json": "*",
     "ext-curl": "*"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "nosto/php-sdk",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
   "license": "BSD-3-Clause",
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "require": {
     "php": ">=5.5",
     "phpseclib/phpseclib": "2.0.* || ~3.0.9",
-    "vlucas/phpdotenv": ">=2.4.0 <=3.6",
+    "vlucas/phpdotenv": "^2.4 || ^3.6",
     "ext-json": "*",
     "ext-curl": "*"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f42b83613e45ee7fe6403f017a04e317",
+    "content-hash": "91d7a714bc0bbe44f705c73461c1864b",
     "packages": [
         {
             "name": "paragonie/constant_time_encoding",
@@ -66,6 +66,11 @@
                 "hex2bin",
                 "rfc4648"
             ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
             "time": "2022-01-17T05:32:27+00:00"
         },
         {
@@ -111,6 +116,11 @@
                 "pseudorandom",
                 "random"
             ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
             "time": "2020-10-15T08:29:30+00:00"
         },
         {
@@ -168,6 +178,10 @@
                 "php",
                 "type"
             ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.8.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/GrahamCampbell",
@@ -269,6 +283,10 @@
                 "x.509",
                 "x509"
             ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.14"
+            },
             "funding": [
                 {
                     "url": "https://github.com/terrafrost",
@@ -348,6 +366,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -425,6 +446,10 @@
                 "env",
                 "environment"
             ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v3.6.10"
+            },
             "funding": [
                 {
                     "url": "https://github.com/GrahamCampbell",
@@ -496,20 +521,24 @@
                 "gherkin",
                 "parser"
             ],
+            "support": {
+                "issues": "https://github.com/Behat/Gherkin/issues",
+                "source": "https://github.com/Behat/Gherkin/tree/v4.9.0"
+            },
             "time": "2021-10-12T13:05:09+00:00"
         },
         {
             "name": "codeception/c3",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/c3.git",
-                "reference": "625318168ecdeedc5162e74435c26320128c4434"
+                "reference": "d228302ac12860a0e92344756aa6eebff54ce171"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/c3/zipball/625318168ecdeedc5162e74435c26320128c4434",
-                "reference": "625318168ecdeedc5162e74435c26320128c4434",
+                "url": "https://api.github.com/repos/Codeception/c3/zipball/d228302ac12860a0e92344756aa6eebff54ce171",
+                "reference": "d228302ac12860a0e92344756aa6eebff54ce171",
                 "shasum": ""
             },
             "require": {
@@ -549,7 +578,11 @@
                 "code coverage",
                 "codecoverage"
             ],
-            "time": "2021-05-18T16:41:09+00:00"
+            "support": {
+                "issues": "https://github.com/Codeception/c3/issues",
+                "source": "https://github.com/Codeception/c3/tree/2.6.5"
+            },
+            "time": "2022-04-28T12:08:33+00:00"
         },
         {
             "name": "codeception/codeception",
@@ -637,6 +670,10 @@
                 "functional testing",
                 "unit testing"
             ],
+            "support": {
+                "issues": "https://github.com/Codeception/Codeception/issues",
+                "source": "https://github.com/Codeception/Codeception/tree/4.1.31"
+            },
             "funding": [
                 {
                     "url": "https://opencollective.com/codeception",
@@ -1079,6 +1116,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -1134,6 +1175,10 @@
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
+            },
             "time": "2021-06-11T22:34:44+00:00"
         },
         {
@@ -1231,6 +1276,10 @@
                 "uri",
                 "url"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.2.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/GrahamCampbell",
@@ -1392,6 +1441,10 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
@@ -1496,6 +1549,10 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
+            "support": {
+                "issues": "https://github.com/pdepend/pdepend/issues",
+                "source": "https://github.com/pdepend/pdepend/tree/2.10.3"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/pdepend/pdepend",
@@ -1693,16 +1750,16 @@
         },
         {
             "name": "phing/phing",
-            "version": "2.17.2",
+            "version": "2.17.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phingofficial/phing.git",
-                "reference": "8b8cee3eb12c24502fc4c227ac5889746248a140"
+                "reference": "053cb496cf49608d19f85664d85d71c48b241667"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phingofficial/phing/zipball/8b8cee3eb12c24502fc4c227ac5889746248a140",
-                "reference": "8b8cee3eb12c24502fc4c227ac5889746248a140",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/053cb496cf49608d19f85664d85d71c48b241667",
+                "reference": "053cb496cf49608d19f85664d85d71c48b241667",
                 "shasum": ""
             },
             "require": {
@@ -1782,6 +1839,11 @@
                 "task",
                 "tool"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phing",
+                "issues": "https://www.phing.info/trac/report",
+                "source": "https://github.com/phingofficial/phing/tree/2.17.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/mrook",
@@ -1796,7 +1858,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-02-09T09:50:58+00:00"
+            "time": "2022-05-04T19:17:50+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1902,6 +1964,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
+            },
             "time": "2021-10-19T17:43:47+00:00"
         },
         {
@@ -1948,6 +2014,10 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
+            },
             "time": "2022-03-15T21:29:03+00:00"
         },
         {
@@ -2020,6 +2090,11 @@
                 "phpmd",
                 "pmd"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.org/phpmd",
+                "issues": "https://github.com/phpmd/phpmd/issues",
+                "source": "https://github.com/phpmd/phpmd/tree/2.12.0"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/phpmd/phpmd",
@@ -2520,20 +2595,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -2562,9 +2637,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -2877,6 +2952,11 @@
                 "reactor",
                 "signal"
             ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/event/issues",
+                "source": "https://github.com/fruux/sabre-event"
+            },
             "time": "2021-11-04T06:51:17+00:00"
         },
         {
@@ -3177,6 +3257,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -3728,6 +3812,10 @@
                     "name": "Markus Staab"
                 }
             ],
+            "support": {
+                "issues": "https://github.com/staabm/annotate-pull-request-from-checkstyle/issues",
+                "source": "https://github.com/staabm/annotate-pull-request-from-checkstyle/tree/1.8.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/staabm",
@@ -3738,16 +3826,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.4.7",
+            "version": "v5.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "05624c386afa1b4ccc1357463d830fade8d9d404"
+                "reference": "9f8964f56f7234f8ace16f66cb3fbae950c04e68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/05624c386afa1b4ccc1357463d830fade8d9d404",
-                "reference": "05624c386afa1b4ccc1357463d830fade8d9d404",
+                "url": "https://api.github.com/repos/symfony/config/zipball/9f8964f56f7234f8ace16f66cb3fbae950c04e68",
+                "reference": "9f8964f56f7234f8ace16f66cb3fbae950c04e68",
                 "shasum": ""
             },
             "require": {
@@ -3796,6 +3884,9 @@
             ],
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v5.4.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3810,7 +3901,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-21T13:42:03+00:00"
+            "time": "2022-04-12T16:02:29+00:00"
         },
         {
             "name": "symfony/console",
@@ -3943,6 +4034,9 @@
             ],
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v5.4.3"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3961,16 +4055,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.37",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "5de6c6e7f52b364840e53851c126be4d71e60470"
+                "reference": "6637e62480b60817b9a6984154a533e8e64c6bd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/5de6c6e7f52b364840e53851c126be4d71e60470",
-                "reference": "5de6c6e7f52b364840e53851c126be4d71e60470",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/6637e62480b60817b9a6984154a533e8e64c6bd5",
+                "reference": "6637e62480b60817b9a6984154a533e8e64c6bd5",
                 "shasum": ""
             },
             "require": {
@@ -4008,6 +4102,9 @@
             ],
             "description": "Provides tools to ease debugging PHP code",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/debug/tree/v4.4.41"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4022,20 +4119,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:41:36+00:00"
+            "time": "2022-04-12T15:19:55+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.7",
+            "version": "v5.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "35588b2afb08ea3a142d62fefdcad4cb09be06ed"
+                "reference": "855e29cd715ad62bb840c9841fe09a7cde50811f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/35588b2afb08ea3a142d62fefdcad4cb09be06ed",
-                "reference": "35588b2afb08ea3a142d62fefdcad4cb09be06ed",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/855e29cd715ad62bb840c9841fe09a7cde50811f",
+                "reference": "855e29cd715ad62bb840c9841fe09a7cde50811f",
                 "shasum": ""
             },
             "require": {
@@ -4094,6 +4191,9 @@
             ],
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4108,7 +4208,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-08T15:43:06+00:00"
+            "time": "2022-04-26T13:08:29+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4158,6 +4258,9 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4240,6 +4343,9 @@
             ],
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.3"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4316,6 +4422,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4377,6 +4486,9 @@
             ],
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.7"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4395,16 +4507,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.3",
+            "version": "v5.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "231313534dded84c7ecaa79d14bc5da4ccb69b7d"
+                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/231313534dded84c7ecaa79d14bc5da4ccb69b7d",
-                "reference": "231313534dded84c7ecaa79d14bc5da4ccb69b7d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9b630f3427f3ebe7cd346c277a1408b00249dad9",
+                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9",
                 "shasum": ""
             },
             "require": {
@@ -4437,6 +4549,9 @@
             ],
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.4.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4451,7 +4566,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-26T16:34:36+00:00"
+            "time": "2022-04-15T08:07:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -4517,6 +4632,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4597,6 +4715,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4673,6 +4794,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.25.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4753,6 +4877,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4821,6 +4948,9 @@
             ],
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v4.4.37"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4878,6 +5008,10 @@
             ],
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
+            "support": {
+                "issues": "https://github.com/theseer/fDOMDocument/issues",
+                "source": "https://github.com/theseer/fDOMDocument/tree/1.6.7"
+            },
             "abandoned": true,
             "time": "2022-01-25T23:10:35+00:00"
         },
@@ -5064,5 +5198,5 @@
         "ext-curl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -1,4 +1,4 @@
-<?php /** @noinspection  PhpUndefinedNamespaceInspections, PhpUndefinedClassInspections, PhpUnnecessaryFullyQualifiedNameInspections */
+<?php
 /**
  * Copyright (c) 2020, Nosto Solutions Ltd
  * All rights reserved.
@@ -44,6 +44,7 @@ class ExportHelper extends AbstractExportHelper
     /**
      * @inheritdoc
      * @suppress PhanAccessMethodInternal
+     * @noinspection PhpUndefinedNamespaceInspections, PhpUndefinedClassInspections, PhpUnnecessaryFullyQualifiedNameInspections
      */
     public function encrypt($secret, $data)
     {

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -47,6 +47,7 @@ class ExportHelper extends AbstractExportHelper
      */
     public function encrypt($secret, $data)
     {
+        //noinspectionstart PhpUndefinedNamespaceInspections, PhpUndefinedClassInspections
         //Check if phpseclib v3 is used
         //needed for comaptibility with Magento 2.4 versions
         if (class_exists("phpseclib3\Crypt\AES")) {
@@ -60,6 +61,7 @@ class ExportHelper extends AbstractExportHelper
         $cipher->setKey($secret);                                                      // @phan-suppress-current-line PhanUndeclaredClassMethod
         $cipher->setIV($iv);                                                           // @phan-suppress-current-line PhanUndeclaredClassMethod
         $cipherText = $cipher->encrypt(SerializationHelper::serialize($data));         // @phan-suppress-current-line PhanUndeclaredClassMethod
+        //noinspectionend
         // Prepend the IV to the cipher string so that nosto can parse and use it.
         // There is no security concern with sending the IV as plain text.
         $data = $iv . $cipherText;

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -43,7 +43,7 @@ class ExportHelper extends AbstractExportHelper
 {
     /**
      * @inheritdoc
-     * @suppress PhanAccessMethodInternal
+     * @suppress PhanAccessMethodInternal, PhanUndeclaredClassConstant, PhanUndeclaredClassMethod
      */
     public function encrypt($secret, $data)
     {
@@ -53,13 +53,13 @@ class ExportHelper extends AbstractExportHelper
             $iv = \phpseclib3\Crypt\Random::string(16);
             $cipher = new \phpseclib3\Crypt\AES('cbc');
         } else {
-            $iv = \phpseclib\Crypt\Random::string(16);                           // @phan-suppress-current-line PhanUndeclaredClassMethod
-            $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\Base::MODE_CBC); // @phan-suppress-current-line PhanUndeclaredClassConstant, PhanUndeclaredClassMethod
+            $iv = \phpseclib\Crypt\Random::string(16);
+            $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\Base::MODE_CBC);
         }
 
-        $cipher->setKey($secret);                                                      // @phan-suppress-current-line PhanUndeclaredClassMethod
-        $cipher->setIV($iv);                                                           // @phan-suppress-current-line PhanUndeclaredClassMethod
-        $cipherText = $cipher->encrypt(SerializationHelper::serialize($data));         // @phan-suppress-current-line PhanUndeclaredClassMethod
+        $cipher->setKey($secret);
+        $cipher->setIV($iv);
+        $cipherText = $cipher->encrypt(SerializationHelper::serialize($data));
         // Prepend the IV to the cipher string so that nosto can parse and use it.
         // There is no security concern with sending the IV as plain text.
         $data = $iv . $cipherText;

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php  /** @noinspection PhpUndefinedNamespaceInspections, PhpUndefinedClassInspections */
 /**
  * Copyright (c) 2020, Nosto Solutions Ltd
  * All rights reserved.
@@ -47,7 +47,6 @@ class ExportHelper extends AbstractExportHelper
      */
     public function encrypt($secret, $data)
     {
-        //noinspectionstart PhpUndefinedNamespaceInspections, PhpUndefinedClassInspections
         //Check if phpseclib v3 is used
         //needed for comaptibility with Magento 2.4 versions
         if (class_exists("phpseclib3\Crypt\AES")) {
@@ -61,7 +60,6 @@ class ExportHelper extends AbstractExportHelper
         $cipher->setKey($secret);                                                      // @phan-suppress-current-line PhanUndeclaredClassMethod
         $cipher->setIV($iv);                                                           // @phan-suppress-current-line PhanUndeclaredClassMethod
         $cipherText = $cipher->encrypt(SerializationHelper::serialize($data));         // @phan-suppress-current-line PhanUndeclaredClassMethod
-        //noinspectionend
         // Prepend the IV to the cipher string so that nosto can parse and use it.
         // There is no security concern with sending the IV as plain text.
         $data = $iv . $cipherText;

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -45,18 +45,21 @@ class ExportHelper extends AbstractExportHelper
      * @inheritdoc
      * @suppress PhanAccessMethodInternal
      * @noinspection PhpUndefinedNamespaceInspections
-     * @noinspection PhpUndefinedClassInspections
-     * @noinspection PhpUnnecessaryFullyQualifiedNameInspections
      */
     public function encrypt($secret, $data)
     {
         //Check if phpseclib v3 is used
         //needed for comaptibility with Magento 2.4 versions
+        /** @noinspection PhpUnnecessaryFullyQualifiedNameInspections */
         if (class_exists("phpseclib3\Crypt\AES")) {
+            /** @noinspection PhpUnnecessaryFullyQualifiedNameInspections */
             $iv = \phpseclib3\Crypt\Random::string(16);
+            /** @noinspection PhpUnnecessaryFullyQualifiedNameInspections */
             $cipher = new \phpseclib3\Crypt\AES('cbc');
         } else {
+            /** @noinspection PhpUndefinedNamespaceInspections,PhpUndefinedClassInspections,PhpUnnecessaryFullyQualifiedNameInspections */
             $iv = \phpseclib\Crypt\Random::string(16);                           // @phan-suppress-current-line PhanUndeclaredClassMethod
+            /** @noinspection PhpUndefinedNamespaceInspections,PhpUndefinedClassInspections,PhpUnnecessaryFullyQualifiedNameInspections */
             $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\Base::MODE_CBC); // @phan-suppress-current-line PhanUndeclaredClassConstant, PhanUndeclaredClassMethod
         }
 

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection ALL */
 /**
  * Copyright (c) 2020, Nosto Solutions Ltd
  * All rights reserved.
@@ -44,22 +44,16 @@ class ExportHelper extends AbstractExportHelper
     /**
      * @inheritdoc
      * @suppress PhanAccessMethodInternal
-     * @noinspection PhpUndefinedNamespaceInspections
      */
     public function encrypt($secret, $data)
     {
         //Check if phpseclib v3 is used
         //needed for comaptibility with Magento 2.4 versions
-        /** @noinspection PhpUnnecessaryFullyQualifiedNameInspections */
         if (class_exists("phpseclib3\Crypt\AES")) {
-            /** @noinspection PhpUnnecessaryFullyQualifiedNameInspections */
             $iv = \phpseclib3\Crypt\Random::string(16);
-            /** @noinspection PhpUnnecessaryFullyQualifiedNameInspections */
             $cipher = new \phpseclib3\Crypt\AES('cbc');
         } else {
-            /** @noinspection PhpUndefinedNamespaceInspections,PhpUndefinedClassInspections,PhpUnnecessaryFullyQualifiedNameInspections */
             $iv = \phpseclib\Crypt\Random::string(16);                           // @phan-suppress-current-line PhanUndeclaredClassMethod
-            /** @noinspection PhpUndefinedNamespaceInspections,PhpUndefinedClassInspections,PhpUnnecessaryFullyQualifiedNameInspections */
             $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\Base::MODE_CBC); // @phan-suppress-current-line PhanUndeclaredClassConstant, PhanUndeclaredClassMethod
         }
 

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -53,13 +53,13 @@ class ExportHelper extends AbstractExportHelper
             $iv = \phpseclib3\Crypt\Random::string(16);
             $cipher = new \phpseclib3\Crypt\AES('cbc');
         } else {
-            $iv = \phpseclib\Crypt\Random::string(16);
-            $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\Base::MODE_CBC);
+            $iv = \phpseclib\Crypt\Random::string(16);                           // @phan-suppress-current-line PhanUndeclaredClassMethod
+            $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\Base::MODE_CBC); // @phan-suppress-current-line PhanUndeclaredClassConstant, PhanUndeclaredClassMethod
         }
 
-        $cipher->setKey($secret);
-        $cipher->setIV($iv);
-        $cipherText = $cipher->encrypt(SerializationHelper::serialize($data));
+        $cipher->setKey($secret);                                                      // @phan-suppress-current-line PhanUndeclaredClassMethod
+        $cipher->setIV($iv);                                                           // @phan-suppress-current-line PhanUndeclaredClassMethod
+        $cipherText = $cipher->encrypt(SerializationHelper::serialize($data));         // @phan-suppress-current-line PhanUndeclaredClassMethod
         // Prepend the IV to the cipher string so that nosto can parse and use it.
         // There is no security concern with sending the IV as plain text.
         $data = $iv . $cipherText;

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -44,7 +44,7 @@ class ExportHelper extends AbstractExportHelper
     /**
      * @inheritdoc
      * @suppress PhanAccessMethodInternal
-     * @noinspection PhpUndefinedNamespaceInspections, PhpUndefinedClassInspections, PhpUnnecessaryFullyQualifiedNameInspections
+     * @noinspection PhpUndefinedNamespaceInspections,PhpUndefinedClassInspections,PhpUnnecessaryFullyQualifiedNameInspections
      */
     public function encrypt($secret, $data)
     {

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -1,4 +1,4 @@
-<?php /** @noinspection ALL */
+<?php /** @noinspection  PhpUndefinedNamespaceInspections, PhpUndefinedClassInspections, PhpUnnecessaryFullyQualifiedNameInspections */
 /**
  * Copyright (c) 2020, Nosto Solutions Ltd
  * All rights reserved.

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -1,4 +1,4 @@
-<?php  /** @noinspection PhpUndefinedNamespaceInspections, PhpUndefinedClassInspections */
+<?php /** @noinspection ALL */
 /**
  * Copyright (c) 2020, Nosto Solutions Ltd
  * All rights reserved.

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -36,9 +36,6 @@
 
 namespace Nosto\Helper;
 
-use phpseclib3\Crypt\AES;
-use phpseclib3\Crypt\Random;
-
 /**
  * Implementation for the export helper
  */
@@ -50,8 +47,16 @@ class ExportHelper extends AbstractExportHelper
      */
     public function encrypt($secret, $data)
     {
-        $iv = Random::string(16);
-        $cipher = new AES('cbc');
+        //Check if phpseclib v3 is used
+        //needed for comaptibility with Magento 2.4 versions
+        if (class_exists("phpseclib3\Crypt\AES")) {
+            $iv = \phpseclib3\Crypt\Random::string(16);
+            $cipher = new \phpseclib3\Crypt\AES('cbc');
+        } else {
+            $iv = \phpseclib\Crypt\Random::string(16);
+            $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\Base::MODE_CBC);
+        }
+
         $cipher->setKey($secret);
         $cipher->setIV($iv);
         $cipherText = $cipher->encrypt(SerializationHelper::serialize($data));

--- a/src/Helper/ExportHelper.php
+++ b/src/Helper/ExportHelper.php
@@ -44,7 +44,9 @@ class ExportHelper extends AbstractExportHelper
     /**
      * @inheritdoc
      * @suppress PhanAccessMethodInternal
-     * @noinspection PhpUndefinedNamespaceInspections,PhpUndefinedClassInspections,PhpUnnecessaryFullyQualifiedNameInspections
+     * @noinspection PhpUndefinedNamespaceInspections
+     * @noinspection PhpUndefinedClassInspections
+     * @noinspection PhpUnnecessaryFullyQualifiedNameInspections
      */
     public function encrypt($secret, $data)
     {

--- a/src/Request/Http/Exception/AbstractHttpException.php
+++ b/src/Request/Http/Exception/AbstractHttpException.php
@@ -59,14 +59,14 @@ abstract class AbstractHttpException extends NostoException
     /**
      * HttpException constructor.
      * @param string $message
-     * @param int|null $code
+     * @param int $code
      * @param Exception|null $previous
      * @param HttpRequest|null $request
      * @param HttpResponse|null $response
      */
     public function __construct(
         $message = "",
-        $code = null,
+        $code = 0,
         Exception $previous = null,
         HttpRequest $request = null,
         HttpResponse $response = null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Magento 2.4.4 requires `phpseclib v3` but M2 2.4.3 requires `phpseclib v2`. 


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
