### PR TITLE
Restore replaceQueryParamsInUrl function

### DIFF
--- a/src/Request/Http/HttpRequest.php
+++ b/src/Request/Http/HttpRequest.php
@@ -157,6 +157,28 @@ class HttpRequest
     }
 
     /**
+     * Replaces or adds a query parameters to a url.
+     *
+     * @param array $queryParams the query params to replace.
+     * @param string $url the url.
+     * @return string the updated url.
+     */
+    public static function replaceQueryParamsInUrl(array $queryParams, $url)
+    {
+        if (empty($queryParams)) {
+            return $url;
+        }
+        $parsedUrl = self::parseUrl($url);
+        $queryString = isset($parsedUrl['query']) ? $parsedUrl['query'] : '';
+        foreach ($queryParams as $param => $value) {
+            $queryString = self::replaceQueryParam($param, $value, $queryString);
+        }
+        $parsedUrl['query'] = $queryString;
+        return self::buildUrl($parsedUrl);
+    }
+
+
+    /**
      * Parses the given url and returns the parts as an array.
      *
      * @see http://php.net/manual/en/function.parse-url.php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Restore replaceQueryParamsInUrl that was deleted during Magento 2 iframe removal release.
<!--- Describe your changes -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
