### PR TITLE
Loosen assertion curl response test message

### DIFF
--- a/tests/unit/HttpRequestTest.php
+++ b/tests/unit/HttpRequestTest.php
@@ -270,11 +270,7 @@ class HttpRequestTest extends Test
             )
         );
         $response = $request->get();
-
-        $pattern = '/Failed to connect to localhost port \d+( after \d+ ms)?: Connection refused/';
-        $string = $response->getMessage();
-
-        $this->assertRegExp($pattern, $string);
+        $this->assertContains('Failed to connect to localhost port', $response->getMessage());
     }
 
     /**


### PR DESCRIPTION
The reason this test fails is the error response string slightly change over different curl versions.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
