### PR TITLE
Fix failing build

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -97,9 +97,20 @@ jobs:
         name: phpmd-xml-result
         path: pmdphpmd.xml
 
-    # - name: Report annotations
-    #   id: report-annotations
-    #   run: ./vendor/bin/pmd2pr --graceful-warnings pmdphpmd.xml
+    - name: Report Mess Detect annotations
+      if: always() && hashFiles('pmdphpmd.xml') != ''
+      run: |
+        php -r "
+        \$xml = simplexml_load_file('pmdphpmd.xml');
+        foreach (\$xml->file as \$file) {
+          \$filepath = (string)\$file['name'];
+          foreach (\$file->violation as \$violation) {
+            \$line = (int)\$violation['beginline'];
+            \$msg = (string)\$violation;
+            echo \"::notice file={\$filepath},line={\$line}::PHPMD: {\$msg}\n\";
+          }
+        }
+        " || true
 
   phpcpd:
     name: Copy-Paste Detect
@@ -146,11 +157,20 @@ jobs:
         name: phdpcpd-xml-result
         path: phdpcpd.xml
 
-    # - name: Report annotations
-    #   id: report-annotations
-    #   run: |
-    #     composer require mridang/cpd-annotations
-    #     ./vendor/bin/cpd2pr phdpcpd.xml
+    - name: Report Copy-Paste Detection annotations
+      if: always() && hashFiles('phdpcpd.xml') != ''
+      run: |
+        php -r "
+        \$xml = simplexml_load_file('phdpcpd.xml');
+        foreach (\$xml->duplication as \$dup) {
+          foreach (\$dup->file as \$file) {
+            \$filepath = (string)\$file['name'];
+            \$line = (int)\$file['line'];
+            \$lines = (int)\$dup['lines'];
+            echo \"::notice file={\$filepath},line={\$line}::PHPCPD: Found {\$lines} duplicate lines\n\";
+          }
+        }
+        " || true
 
   package:
     name: Package

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -97,7 +97,7 @@ jobs:
         name: phpmd-xml-result
         path: pmdphpmd.xml
 
-    - name: Report Mess Detect annotations
+    - name: Detect code standard violations
       if: always() && hashFiles('pmdphpmd.xml') != ''
       run: |
         php -r "
@@ -157,7 +157,7 @@ jobs:
         name: phdpcpd-xml-result
         path: phdpcpd.xml
 
-    - name: Report Copy-Paste Detection annotations
+    - name: Detect duplicate lines
       if: always() && hashFiles('phdpcpd.xml') != ''
       run: |
         php -r "

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -97,9 +97,9 @@ jobs:
         name: phpmd-xml-result
         path: pmdphpmd.xml
 
-    - name: Report annotations
-      id: report-annotations
-      run: ./vendor/bin/pmd2pr --graceful-warnings pmdphpmd.xml
+    # - name: Report annotations
+    #   id: report-annotations
+    #   run: ./vendor/bin/pmd2pr --graceful-warnings pmdphpmd.xml
 
   phpcpd:
     name: Copy-Paste Detect
@@ -146,11 +146,11 @@ jobs:
         name: phdpcpd-xml-result
         path: phdpcpd.xml
 
-    - name: Report annotations
-      id: report-annotations
-      run: |
-        composer require mridang/cpd-annotations
-        ./vendor/bin/cpd2pr phdpcpd.xml
+    # - name: Report annotations
+    #   id: report-annotations
+    #   run: |
+    #     composer require mridang/cpd-annotations
+    #     ./vendor/bin/cpd2pr phdpcpd.xml
 
   package:
     name: Package

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "codeception/codeception": "4.1.*",
     "codeception/module-asserts": "1.3.*",
     "phan/phan": "2.6",
-    "staabm/annotate-pull-request-from-checkstyle": "^1.1",
-    "mridang/pmd-annotations": "^0.0.2"
+    "staabm/annotate-pull-request-from-checkstyle": "^1.1"
   },
   "repositories": [
     {
@@ -45,8 +44,6 @@
     "ext-curl": "*"
   },
   "scripts": {
-    "post-install-cmd": "if [ -f ./vendor/bin/phpcs ]; then \"vendor/bin/phpcs\" --config-set installed_paths vendor/wimg/php-compatibility; fi",
-    "post-update-cmd": "if [ -f ./vendor/bin/phpcs ]; then \"vendor/bin/phpcs\" --config-set installed_paths vendor/wimg/php-compatibility; fi",
     "ci:inspect": "./inspect.sh"
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e4e15d12bd37d6338373e0bead0acf6",
+    "content-hash": "a5c888b06368782ab6d45bb22e320743",
     "packages": [
         {
             "name": "paragonie/constant_time_encoding",
@@ -1257,55 +1257,6 @@
             ],
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
             "time": "2020-02-18T02:57:19+00:00"
-        },
-        {
-            "name": "mridang/pmd-annotations",
-            "version": "0.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mridang/pmd-annotations.git",
-                "reference": "0fcaf0e31698c4d81ddb6fa2538edfda8123a7a2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mridang/pmd-annotations/zipball/0fcaf0e31698c4d81ddb6fa2538edfda8123a7a2",
-                "reference": "0fcaf0e31698c4d81ddb6fa2538edfda8123a7a2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.5"
-            },
-            "bin": [
-                "pmd2pr"
-            ],
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mridang Agarwalla"
-                }
-            ],
-            "description": "Turns PMD style XML reports into Github pull-request annotations via the Checks API. This script is meant for use within your Github Action.",
-            "keywords": [
-                "actions",
-                "annotations",
-                "github",
-                "pmd"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/mridang",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-03-31T08:41:21+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4896,7 +4847,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -4904,6 +4855,6 @@
         "ext-json": "*",
         "ext-curl": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5c888b06368782ab6d45bb22e320743",
+    "content-hash": "9c752c628d90348ad5763353e2f2c8e1",
     "packages": [
         {
             "name": "paragonie/constant_time_encoding",

--- a/tests/unit/Util/GraphQLUtilsTest.php
+++ b/tests/unit/Util/GraphQLUtilsTest.php
@@ -12,14 +12,14 @@ class GraphQLUtilsTest extends Test
     public function propertyValueProvider()
     {
         return [
-            ['boolean value' => 'someRandomKey', true],
-            ['string value' => 'someRandomKey', 'testValue'],
-            ['int value' => 'someRandomKey', 187],
-            ['float value' => 'someRandomKey', 1.87],
-            ['array value' => 'someRandomKey', ['testValue']],
-            ['null' => 'someRandomKey', null],
-            ['empty value' => 'someRandomKey', ''],
-            ['non existent key' => 'sabdsajkdas', null],
+            'boolean value' => ['someRandomKey', true],
+            'string value' => ['someRandomKey', 'testValue'],
+            'int value' => ['someRandomKey', 187],
+            'float value' => ['someRandomKey', 1.87],
+            'array value' => ['someRandomKey', ['testValue']],
+            'null' => ['someRandomKey', null],
+            'empty value' => ['someRandomKey', ''],
+            'non existent key' => ['sabdsajkdas', null],
         ];
     }
 


### PR DESCRIPTION
The SDK was failing to install on PHP 8.3 due to dead dependency mridang/pmd-annotations (404 on Github), failing post-install/post-update scripts in composer.json that use deprecated phpcs syntax incompatible in PHP 8.3.

The solution was to remove dead mridang/pmd-annotations package and remove the failing post-install-cmd and post-update-cmd scripts, the GraphQLUtilsTest.php was updated as well for compatibility

### Note
This should be a temporary fix. A separate ticket will be created to modernize the dev dependencies